### PR TITLE
added cls name to snapshot.test_name (if exists)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ pip install -e ".[test]"
 After developing, the full test suite can be evaluated by running:
 
 ```sh
-py.test tests --cov=snapshottest
+py.test
 ```
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
 [flake8]
 exclude = tests,examples,setup.py
 max-line-length = 120
+
+[tool:pytest]
+addopts = --cov snapshottest
+testpaths = tests

--- a/snapshottest/pytest.py
+++ b/snapshottest/pytest.py
@@ -39,7 +39,9 @@ class PyTestSnapshotTest(SnapshotTest):
 
     @property
     def test_name(self):
-        return '{} {}'.format(
+        cls_name = getattr(self.request.node.cls, '__name__', '')
+        return '{}{} {}'.format(
+            '{}.'.format(cls_name) if cls_name else '',
             self.request.node.name,
             self.curr_snapshot
         )

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -1,0 +1,35 @@
+import pytest
+
+from snapshottest.pytest import PyTestSnapshotTest
+import snapshottest
+from snapshottest.pytest import (
+    PyTestSnapshotTest,
+    SnapshotSession,
+)
+
+
+@pytest.fixture
+def options():
+    return {}
+
+
+@pytest.fixture
+def _apply_options(request, monkeypatch, options):
+    for k, v in options.items():
+        monkeypatch.setattr(request.config, k, v, raising=False)
+
+
+@pytest.fixture
+def pytest_snapshot_test(request, _apply_options):
+    return PyTestSnapshotTest(request)
+
+
+class TestPyTestSnapShotTest:
+    def test_property_test_name(self, pytest_snapshot_test):
+        assert pytest_snapshot_test.test_name == \
+            'TestPyTestSnapShotTest.test_property_test_name 1'
+
+
+def test_pytest_snapshottest_property_test_name(pytest_snapshot_test):
+    assert pytest_snapshot_test.test_name == \
+        'test_pytest_snapshottest_property_test_name 1'


### PR DESCRIPTION
I also updated testing docs to reflect `setup.cfg`'s new `[tool:pytest]` section that auto provided suggested pytest options.