### PR TITLE
Distribute as a universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bdist_wheel]
+universal = 1
+
 [flake8]
 exclude = tests,examples,setup.py
 max-line-length = 120


### PR DESCRIPTION
Advantages of wheels

* Faster installation for pure python packages
* Avoids arbitrary code execution for installation -- avoids `setup.py`
* Allows better caching for testing and continuous integration
* Creates `.pyc` files as part of installation to ensure they match the python interpreter used
* More consistent installs across platforms and machines

As snapshot is a pure Python package (no C code), it can safely be distributed as a universal wheel.

When you'd normally run `python setup.py sdist upload`, run instead `python setup.py sdist bdist_wheel upload`.

For general information on wheel and its use, see:

http://pythonwheels.com/

For information on the wheel standard, see PEP 427:

https://www.python.org/dev/peps/pep-0427/