### PR TITLE
Support named snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ class APITestCase(TestCase):
         """Testing the API for /me"""
         my_api_response = api.client.get('/me')
         self.assertMatchSnapshot(my_api_response)
+
+        # Set custom snapshot name: `gpg_response`
+        my_gpg_response = api.client.get('/me?gpg_key')
+        self.assertMatchSnapshot(my_gpg_response, 'gpg_response')
 ```
 
 If you want to update the snapshots automatically you can use the `nosetests --snapshot-update`.
@@ -44,6 +48,10 @@ def test_mything(snapshot):
     """Testing the API for /me"""
     my_api_response = api.client.get('/me')
     snapshot.assert_match(my_api_response)
+
+    # Set custom snapshot name: `gpg_response`
+    my_gpg_response = api.client.get('/me?gpg_key')
+    snapshot.assert_match(my_gpg_response, 'gpg_response')
 ```
 
 If you want to update the snapshots automatically you can use the `--snapshot-update` config.

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,10 @@ Usage with unittest/nose
             my_api_response = api.client.get('/me')
             self.assertMatchSnapshot(my_api_response)
 
+            # Set custom snapshot name: `gpg_response`
+            my_gpg_response = api.client.get('/me?gpg_key')
+            self.assertMatchSnapshot(my_gpg_response, 'gpg_response')
+
 If you want to update the snapshots automatically you can use the
 ``nosetests --snapshot-update``.
 
@@ -53,11 +57,40 @@ Usage with pytest
         my_api_response = api.client.get('/me')
         snapshot.assert_match(my_api_response)
 
+        # Set custom snapshot name: `gpg_response`
+        my_gpg_response = api.client.get('/me?gpg_key')
+        snapshot.assert_match(my_gpg_response, 'gpg_response')
+
 If you want to update the snapshots automatically you can use the
 ``--snapshot-update`` config.
 
 Check the `Pytest
 example <https://github.com/syrusakbary/snapshottest/tree/master/examples/pytest>`__.
+
+Usage with django
+-----------------
+
+Add to your settings:
+
+.. code:: python
+
+    TEST_RUNNER = 'snapshottest.django.TestRunner'
+
+To create your snapshottest:
+
+.. code:: python
+
+    from snapshottest.django import TestCase
+
+    class APITestCase(TestCase):
+        def test_api_me(self):
+            """Testing the API for /me"""
+            my_api_response = api.client.get('/me')
+            self.assertMatchSnapshot(my_api_response)
+
+If you want to update the snapshots automatically you can use the
+``python manage.py test --snapshot-update``. Check the `Django
+example <https://github.com/syrusakbary/snapshottest/tree/master/examples/django_project>`__.
 
 Contributing
 ============
@@ -72,7 +105,7 @@ After developing, the full test suite can be evaluated by running:
 
 .. code:: sh
 
-    py.test tests --cov=snapshottest
+    py.test
 
 Notes
 =====

--- a/snapshottest/module.py
+++ b/snapshottest/module.py
@@ -180,7 +180,8 @@ class SnapshotTest(object):
     update = False
 
     def __init__(self):
-        self.curr_snapshot = 1
+        self.curr_snapshot = ''
+        self.snapshot_counter = 1
 
     @property
     def module(self):
@@ -210,12 +211,12 @@ class SnapshotTest(object):
 
     def store(self, data):
         self.module[self.test_name] = data
-        self.curr_snapshot += 1
 
     def assert_equals(self, value, snapshot):
         assert value == snapshot
 
-    def assert_match(self, value):
+    def assert_match(self, value, name=''):
+        self.curr_snapshot = name or self.snapshot_counter
         self.visit()
         prev_snapshot = not self.update and self.module[self.test_name]
         if prev_snapshot:
@@ -229,13 +230,15 @@ class SnapshotTest(object):
                 raise
 
         self.store(value)
+        if not name:
+            self.snapshot_counter += 1
 
     def save_changes(self):
         self.module.save()
 
 
-def assert_match_snapshot(value):
+def assert_match_snapshot(value, name=''):
     if not SnapshotTest._current_tester:
         raise Exception("You need to use assert_match_snapshot in the SnapshotTest context.")
 
-    SnapshotTest._current_tester.assert_match(value)
+    SnapshotTest._current_tester.assert_match(value, name)

--- a/snapshottest/unittest.py
+++ b/snapshottest/unittest.py
@@ -101,7 +101,7 @@ class TestCase(unittest.TestCase):
         SnapshotTest._current_tester = None
         self._snapshot = None
 
-    def assert_match_snapshot(self, value):
-        self._snapshot.assert_match(value)
+    def assert_match_snapshot(self, value, name=''):
+        self._snapshot.assert_match(value, name='')
 
     assertMatchSnapshot = assert_match_snapshot

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -21,10 +21,28 @@ def pytest_snapshot_test(request, _apply_options):
 
 class TestPyTestSnapShotTest:
     def test_property_test_name(self, pytest_snapshot_test):
+        pytest_snapshot_test.assert_match('counter')
         assert pytest_snapshot_test.test_name == \
             'TestPyTestSnapShotTest.test_property_test_name 1'
 
+        pytest_snapshot_test.assert_match('named', 'named_test')
+        assert pytest_snapshot_test.test_name == \
+            'TestPyTestSnapShotTest.test_property_test_name named_test'
+
+        pytest_snapshot_test.assert_match('counter')
+        assert pytest_snapshot_test.test_name == \
+            'TestPyTestSnapShotTest.test_property_test_name 2'
+
 
 def test_pytest_snapshottest_property_test_name(pytest_snapshot_test):
-    assert pytest_snapshot_test.test_name == \
-        'test_pytest_snapshottest_property_test_name 1'
+        pytest_snapshot_test.assert_match('counter')
+        assert pytest_snapshot_test.test_name == \
+            'test_pytest_snapshottest_property_test_name 1'
+
+        pytest_snapshot_test.assert_match('named', 'named_test')
+        assert pytest_snapshot_test.test_name == \
+            'test_pytest_snapshottest_property_test_name named_test'
+
+        pytest_snapshot_test.assert_match('counter')
+        assert pytest_snapshot_test.test_name == \
+            'test_pytest_snapshottest_property_test_name 2'


### PR DESCRIPTION
Closes #17 

Added support for named snapshots, eg:

```python
# pytest
snapshot.assertMatch(value [, name = ''])

# unittest
UnitTestSnapshotTest.assertMatchSnapshot(value [, name = ''])
```

By default, auto-inrcemented counter is used as a name.