### PR TITLE
Fix `--snapshot-update` for nose

### DIFF
--- a/snapshottest/nose.py
+++ b/snapshottest/nose.py
@@ -42,7 +42,7 @@ class SnapshotTestPlugin(Plugin):
 
     def wantClass(self, cls):
         if issubclass(cls, TestCase):
-            cls._snapshot_should_update = self.snapshot_update
+            cls.snapshot_should_update = self.snapshot_update
 
     def afterContext(self):
         if self.snapshot_update:


### PR DESCRIPTION
`--snapshot-update` updates `cls._snapshot_should_update` while doing test discovery. The actual class variable is `cls.snapshot_should_update` - I spent a lot of time being confused as to why this was updating the class, but it would never update the snapshots :) 

thanks for the project though!  I love snapshots in Jest for testing simple input -> expected output style tests.  