### PR TITLE
Fix: asserting objects against snapshots is never successful

### DIFF
--- a/snapshottest/diff.py
+++ b/snapshottest/diff.py
@@ -22,12 +22,12 @@ def format_line(line):
 
 class PrettyDiff(object):
     def __init__(self, obj, snapshottest):
-        if isinstance(obj, dict):
-            obj = SortedDict(**obj)
-        self.obj = obj
         self.pretty = Formatter()
         self.differ = Differ()
         self.snapshottest = snapshottest
+        if isinstance(obj, dict):
+            obj = SortedDict(**obj)
+        self.obj = self.pretty(obj)
 
     def __eq__(self, other):
         return isinstance(other, PrettyDiff) and self.obj == other.obj

--- a/snapshottest/generic_repr.py
+++ b/snapshottest/generic_repr.py
@@ -4,6 +4,8 @@ class GenericRepr(object):
 
     def __repr__(self):
         representation = repr(self.obj)
+        if "'{}'".format(self.obj) == representation:
+            representation = self.obj
         # We remove the hex id, if found
         representation = representation.replace(hex(id(self.obj)), "0x100000000")
         return 'GenericRepr("{}")'.format(representation)

--- a/snapshottest/generic_repr.py
+++ b/snapshottest/generic_repr.py
@@ -4,7 +4,7 @@ class GenericRepr(object):
 
     def __repr__(self):
         representation = repr(self.obj)
-        if "'{}'".format(self.obj) == representation:
+        if "'{}'".format(self.obj) == representation or '"{}"'.format(self.obj) == representation:
             representation = self.obj
         # We remove the hex id, if found
         representation = representation.replace(hex(id(self.obj)), "0x100000000")

--- a/snapshottest/module.py
+++ b/snapshottest/module.py
@@ -31,7 +31,7 @@ class SnapshotModule(object):
             source = imp.load_source(self.module, self.filepath)
             assert isinstance(source.snapshots, Snapshot)
             return source.snapshots
-        except:
+        except BaseException:
             return Snapshot()
 
     def visit(self, snapshot_name):
@@ -50,9 +50,9 @@ class SnapshotModule(object):
         unvisited_snapshots = 0
         unvisited_modules = 0
         for module in cls.get_modules():
-            l = len(module.unvisited_snapshots)
-            unvisited_snapshots += l
-            unvisited_modules += min(l, 1)
+            unvisited_snapshot_len = len(module.unvisited_snapshots)
+            unvisited_snapshots += unvisited_snapshot_len
+            unvisited_modules += min(unvisited_snapshot_len, 1)
 
         return unvisited_snapshots, unvisited_modules
 
@@ -65,9 +65,9 @@ class SnapshotModule(object):
         count_snapshots = 0
         count_modules = 0
         for module in SnapshotModule._snapshot_modules.values():
-            l = getter(module)
-            count_snapshots += l
-            count_modules += min(l, 1)
+            length = getter(module)
+            count_snapshots += length
+            count_modules += min(length, 1)
 
         return count_snapshots, count_modules
 
@@ -225,7 +225,7 @@ class SnapshotTest(object):
                     PrettyDiff(value, self),
                     PrettyDiff(prev_snapshot, self)
                 )
-            except:
+            except BaseException:
                 self.fail()
                 raise
 


### PR DESCRIPTION
The snapshot stores objects as GenericRepr, while the value contains the original object. This cannot match, so we format values prior to assertion to then compare GenericReprs to GenericReprs.