### PR TITLE
Fix Unicode characters

### DIFF
--- a/snapshottest/module.py
+++ b/snapshottest/module.py
@@ -1,3 +1,4 @@
+import codecs
 import os
 import imp
 from collections import defaultdict
@@ -139,7 +140,7 @@ class SnapshotModule(object):
 
         pretty = Formatter(self.imports)
 
-        with open(self.filepath, 'w', encoding="utf-8") as snapshot_file:
+        with codecs.open(self.filepath, 'w', encoding="utf-8") as snapshot_file:
             snapshots_declarations = []
             for key, value in self.snapshots.items():
                 snapshots_declarations.append('''snapshots['{}'] = {}'''.format(key, pretty(value)))

--- a/snapshottest/module.py
+++ b/snapshottest/module.py
@@ -139,7 +139,7 @@ class SnapshotModule(object):
 
         pretty = Formatter(self.imports)
 
-        with open(self.filepath, 'w') as snapshot_file:
+        with open(self.filepath, 'w', encoding="utf-8") as snapshot_file:
             snapshots_declarations = []
             for key, value in self.snapshots.items():
                 snapshots_declarations.append('''snapshots['{}'] = {}'''.format(key, pretty(value)))


### PR DESCRIPTION
Fixes issue: #16 

Added encoded argument when handling files. Besides the Unicode issue, this is also a good practice when the intention is for the code to be cross-platform (because the default encoding on Windows differs from the default encoding on Mac/Linux).