### PR TITLE
Ignore fields parameter in assert methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ class APITestCase(TestCase):
         # Set custom snapshot name: `gpg_response`
         my_gpg_response = api.client.get('/me?gpg_key')
         self.assertMatchSnapshot(my_gpg_response, 'gpg_response')
+
+        # Set ignore fields (e.g. 'created_at' : '12-12-2017')
+        ignore_date_response = {'created_at' : '01-01-2018', 'url': '/me'}
+        self.assertMatchSnapshot(ignore_date_response, ignore_fields=['created_at'])
 ```
 
 If you want to update the snapshots automatically you can use the `nosetests --snapshot-update`.
@@ -52,6 +56,10 @@ def test_mything(snapshot):
     # Set custom snapshot name: `gpg_response`
     my_gpg_response = api.client.get('/me?gpg_key')
     snapshot.assert_match(my_gpg_response, 'gpg_response')
+
+    # Set ignore fields (e.g. 'created_at' : '12-12-2017')
+    ignore_date_response = {'created_at' : '01-01-2018', 'url': '/me'}
+    snapshot.assert_match(ignore_date_response, ignore_fields=['created_at'])
 ```
 
 If you want to update the snapshots automatically you can use the `--snapshot-update` config.

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,10 @@ Usage with unittest/nose
             my_gpg_response = api.client.get('/me?gpg_key')
             self.assertMatchSnapshot(my_gpg_response, 'gpg_response')
 
+            # Set ignore fields (e.g. 'created_at' : '12-12-2017')
+            ignore_date_response = {'created_at' : '01-01-2018', 'url': '/me'}
+            self.assertMatchSnapshot(ignore_date_response, ignore_fields=['created_at'])
+
 If you want to update the snapshots automatically you can use the
 ``nosetests --snapshot-update``.
 
@@ -60,6 +64,10 @@ Usage with pytest
         # Set custom snapshot name: `gpg_response`
         my_gpg_response = api.client.get('/me?gpg_key')
         snapshot.assert_match(my_gpg_response, 'gpg_response')
+
+        # Set ignore fields (e.g. 'created_at' : '12-12-2017')
+        ignore_date_response = {'created_at' : '01-01-2018', 'url': '/me'}
+        snapshot.assert_match(ignore_date_response, ignore_fields=['created_at'])
 
 If you want to update the snapshots automatically you can use the
 ``--snapshot-update`` config.

--- a/snapshottest/module.py
+++ b/snapshottest/module.py
@@ -215,11 +215,18 @@ class SnapshotTest(object):
     def assert_equals(self, value, snapshot):
         assert value == snapshot
 
-    def assert_match(self, value, name=''):
+    def assert_match(self, value, name='', ignore_fields=None):
         self.curr_snapshot = name or self.snapshot_counter
         self.visit()
         prev_snapshot = not self.update and self.module[self.test_name]
         if prev_snapshot:
+            if ignore_fields is None:
+                ignore_fields = []
+            for field in ignore_fields:
+                if field in prev_snapshot:
+                    del prev_snapshot[field]
+                if field in value:
+                    del value[field]
             try:
                 self.assert_equals(
                     PrettyDiff(value, self),
@@ -237,8 +244,8 @@ class SnapshotTest(object):
         self.module.save()
 
 
-def assert_match_snapshot(value, name=''):
+def assert_match_snapshot(value, name='', ignore_fields=None):
     if not SnapshotTest._current_tester:
         raise Exception("You need to use assert_match_snapshot in the SnapshotTest context.")
 
-    SnapshotTest._current_tester.assert_match(value, name)
+    SnapshotTest._current_tester.assert_match(value, name, ignore_fields)

--- a/snapshottest/module.py
+++ b/snapshottest/module.py
@@ -216,17 +216,12 @@ class SnapshotTest(object):
         assert value == snapshot
 
     def assert_match(self, value, name='', ignore_fields=None):
+        self.remove_fields_from_dict(value, ignore_fields)
         self.curr_snapshot = name or self.snapshot_counter
         self.visit()
         prev_snapshot = not self.update and self.module[self.test_name]
         if prev_snapshot:
-            if ignore_fields is None:
-                ignore_fields = []
-            for field in ignore_fields:
-                if field in prev_snapshot:
-                    del prev_snapshot[field]
-                if field in value:
-                    del value[field]
+            self.remove_fields_from_dict(prev_snapshot, ignore_fields)
             try:
                 self.assert_equals(
                     PrettyDiff(value, self),
@@ -242,6 +237,14 @@ class SnapshotTest(object):
 
     def save_changes(self):
         self.module.save()
+
+    @classmethod
+    def remove_fields_from_dict(cls, dictionary, remove_fields=None):
+        if remove_fields is None:
+            remove_fields = []
+        for field in remove_fields:
+            if field in dictionary:
+                del dictionary[field]
 
 
 def assert_match_snapshot(value, name='', ignore_fields=None):

--- a/snapshottest/unittest.py
+++ b/snapshottest/unittest.py
@@ -101,7 +101,7 @@ class TestCase(unittest.TestCase):
         SnapshotTest._current_tester = None
         self._snapshot = None
 
-    def assert_match_snapshot(self, value, name=''):
-        self._snapshot.assert_match(value, name='')
+    def assert_match_snapshot(self, value, name='', ignore_fields=None):
+        self._snapshot.assert_match(value, name, ignore_fields)
 
     assertMatchSnapshot = assert_match_snapshot

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -46,3 +46,14 @@ def test_pytest_snapshottest_property_test_name(pytest_snapshot_test):
         pytest_snapshot_test.assert_match('counter')
         assert pytest_snapshot_test.test_name == \
             'test_pytest_snapshottest_property_test_name 2'
+
+
+def test_pytest_snapshottest_ignore_fields(pytest_snapshot_test):
+    ignore_fields_test = {
+        'url': 'example',
+        'date': '12-12-2017'
+    }
+
+    pytest_snapshot_test.assert_match(ignore_fields_test, 'ignore_fields_test', ignore_fields=['date'])
+    ignore_fields_test.pop('date', None)
+    assert pytest_snapshot_test.module[pytest_snapshot_test.test_name] == ignore_fields_test


### PR DESCRIPTION
Fixed issue: #21 

Added parameter to assert methods that can ignore single or multiple fields (given as a list) in snapshot.