### PR TITLE
Setting snapshot_should_update of snapshottest.unittest.TestCase

### DIFF
--- a/snapshottest/django.py
+++ b/snapshottest/django.py
@@ -13,7 +13,7 @@ class TestRunner(DiscoverRunner):
 
     def __init__(self, snapshot_update=False, **kwargs):
         super(TestRunner, self).__init__(**kwargs)
-        TestCase.snapshot_should_update = snapshot_update
+        uTestCase.snapshot_should_update = snapshot_update
 
     @classmethod
     def add_arguments(cls, parser):


### PR DESCRIPTION
We are setting this instead of snapshot.django.TestCase as this allows users to override the default testcase and still be able to use default TEST_RUNNER. Example usecase would be when they want to use something like APITestCase from [DRF](http://www.django-rest-framework.org)