### PR TITLE
Fix for false PASS on Windows with german umlauts

### DIFF
--- a/snapshottest/module.py
+++ b/snapshottest/module.py
@@ -1,4 +1,5 @@
 import os
+from io import open
 import imp
 from collections import defaultdict
 import logging

--- a/snapshottest/module.py
+++ b/snapshottest/module.py
@@ -139,7 +139,7 @@ class SnapshotModule(object):
 
         pretty = Formatter(self.imports)
 
-        with open(self.filepath, 'w') as snapshot_file:
+        with open(self.filepath, 'w', encoding='utf-8') as snapshot_file:
             snapshots_declarations = []
             for key, value in self.snapshots.items():
                 snapshots_declarations.append('''snapshots['{}'] = {}'''.format(key, pretty(value)))

--- a/snapshottest/module.py
+++ b/snapshottest/module.py
@@ -149,7 +149,7 @@ class SnapshotModule(object):
                 'from {} import {}'.format(module, ', '.join(module_imports))
                 for module, module_imports in self.imports.items()
             ])
-            snapshot_file.write('''# -*- coding: utf-8 -*-
+            snapshot_file.write(u'''# -*- coding: utf-8 -*-
 # snapshottest: v1 - https://goo.gl/zC4yUc
 from __future__ import unicode_literals
 


### PR DESCRIPTION
On windows and when using e.g. german umlauts in the snapshot data received from the api, all tests wrongfully pass. load_snapshot() throws an error due to the umlauts (and windows default ansi encoding) and goes to except and simply creates a new snapshot, so changes are never seen and the tests pass even though they should fail.

(using pytest on windows, python 3.5.2)

Test with examples/pytest changed to 
def api_client_get(url):
    return {
        'url': 'umlaut üöä',
    }
