### PR TITLE
changed GenericRepr to use triple-quoted strings

### DIFF
--- a/snapshottest/generic_repr.py
+++ b/snapshottest/generic_repr.py
@@ -8,7 +8,7 @@ class GenericRepr(object):
             representation = self.obj
         # We remove the hex id, if found
         representation = representation.replace(hex(id(self.obj)), "0x100000000")
-        return 'GenericRepr("{}")'.format(representation)
+        return 'GenericRepr("""{}""")'.format(representation)
 
     def __eq__(self, other):
         return isinstance(other, GenericRepr) and repr(self) == repr(other)


### PR DESCRIPTION
GenericRepr was using single quoted strings which was caused multi-line strings to fail on CI linting.