### PR TITLE
Don't swallow errors loading snapshots

### DIFF
--- a/snapshottest/module.py
+++ b/snapshottest/module.py
@@ -1,4 +1,5 @@
 import codecs
+import errno
 import os
 import imp
 from collections import defaultdict
@@ -30,10 +31,15 @@ class SnapshotModule(object):
     def load_snapshots(self):
         try:
             source = imp.load_source(self.module, self.filepath)
+        # except FileNotFoundError:  # Python 3
+        except (IOError, OSError) as err:
+            if err.errno == errno.ENOENT:
+                return Snapshot()
+            else:
+                raise
+        else:
             assert isinstance(source.snapshots, Snapshot)
             return source.snapshots
-        except BaseException:
-            return Snapshot()
 
     def visit(self, snapshot_name):
         self.visited_snapshots.add(snapshot_name)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,0 +1,29 @@
+from __future__ import unicode_literals
+
+import pytest
+
+from snapshottest import Snapshot
+from snapshottest.module import SnapshotModule
+
+
+class TestSnapshotModuleLoading(object):
+    def test_load_not_yet_saved(self, tmpdir):
+        filepath = tmpdir.join("snap_new.py")
+        assert not filepath.check()  # file does not exist
+        module = SnapshotModule("tests.snapshots.snap_new", str(filepath))
+        snapshots = module.load_snapshots()
+        assert isinstance(snapshots, Snapshot)
+
+    def test_load_missing_package(self, tmpdir):
+        filepath = tmpdir.join("snap_import.py")
+        filepath.write_text("import missing_package\n", "utf-8")
+        module = SnapshotModule("tests.snapshots.snap_import", str(filepath))
+        with pytest.raises(ImportError):
+            module.load_snapshots()
+
+    def test_load_corrupted_snapshot(self, tmpdir):
+        filepath = tmpdir.join("snap_error.py")
+        filepath.write_text("<syntax error>\n", "utf-8")
+        module = SnapshotModule("tests.snapshots.snap_error", str(filepath))
+        with pytest.raises(SyntaxError):
+            module.load_snapshots()


### PR DESCRIPTION
If a snapshots file becomes corrupted, or tries to import missing
packages (e.g., after dependency changes), or is otherwise not loadable,
running the tests should result in an error. (Not silently regenerate
the snapshots file and pass the tests.)

[Makes snapshot code generation error in #44 visible, and addresses
@mprostock's comment in #24.]