### PR TITLE
Fix Python 2 multiline unicode formatting

### DIFF
--- a/examples/pytest/snapshots/snap_test_demo.py
+++ b/examples/pytest/snapshots/snap_test_demo.py
@@ -10,3 +10,5 @@ snapshots = Snapshot()
 snapshots['test_me_endpoint 1'] = {
     'url': '/me'
 }
+
+snapshots['test_unicode 1'] = u'p\xe9p\xe8re'

--- a/examples/pytest/test_demo.py
+++ b/examples/pytest/test_demo.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+
 def api_client_get(url):
     return {
         'url': url,

--- a/examples/pytest/test_demo.py
+++ b/examples/pytest/test_demo.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 def api_client_get(url):
     return {
         'url': url,
@@ -8,3 +10,9 @@ def test_me_endpoint(snapshot):
     """Testing the API for /me"""
     my_api_response = api_client_get('/me')
     snapshot.assert_match(my_api_response)
+
+
+def test_unicode(snapshot):
+    """Simple test with unicode"""
+    expect = u'pépère'
+    snapshot.assert_match(expect)

--- a/snapshottest/formatter.py
+++ b/snapshottest/formatter.py
@@ -53,7 +53,7 @@ class Formatter(object):
             # Is a multiline string, so we use '''{}''' for the repr
             return trepr(value)
 
-        return repr(str(value))
+        return repr(value)
 
     def format_std_type(self, value, indent):
         return repr(value)

--- a/snapshottest/formatter.py
+++ b/snapshottest/formatter.py
@@ -5,7 +5,7 @@ from .generic_repr import GenericRepr
 
 
 def trepr(s):
-    text = '\n'.join([repr(line)[1:-1] for line in s.split('\n')])
+    text = '\n'.join([repr(line).lstrip('u')[1:-1] for line in s.split('\n')])
     quotes, dquotes = "'''", '"""'
     if quotes in text:
         if dquotes in text:
@@ -53,7 +53,9 @@ class Formatter(object):
             # Is a multiline string, so we use '''{}''' for the repr
             return trepr(value)
 
-        return repr(value)
+        # Snapshots are saved with `from __future__ import unicode_literals`,
+        # so the `u'...'` repr is unnecessary, even on Python 2
+        return repr(value).lstrip('u')
 
     def format_std_type(self, value, indent):
         return repr(value)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+import six
+
+from snapshottest.formatter import Formatter
+
+
+@pytest.mark.parametrize("text_value, expected", [
+    # basics
+    ("abc", "'abc'"),
+    ("", "''"),
+    ("back\\slash", "'back\\\\slash'"),
+    # various embedded quotes (single line)
+    ("""it has "double quotes".""", """'it has "double quotes".'"""),
+    ("""it's got single quotes""", '''"it's got single quotes"'''),
+    ("""it's got "both quotes".""", """'it\\'s got "both quotes".'"""),
+    # multiline gets formatted as triple-quoted
+    ("one\ntwo\n", "'''one\ntwo\n'''"),
+    ("three\n'''quotes", "\"\"\"three\n'''quotes\"\"\""),
+    ("so many\"\"\"\n'''quotes", "'''so many\"\"\"\n\\'\\'\\'quotes'''"),
+])
+def test_text_formatting(text_value, expected):
+    formatter = Formatter()
+    formatted = formatter(text_value)
+    assert formatted == expected
+
+    if six.PY2:
+        # Also check that Python 2 str value formats the same as the unicode value.
+        # (If a test case raises UnicodeEncodeError in here, it should be moved to
+        # the non_ascii verson of this test, below.)
+        py2_str_value = text_value.encode("ASCII")
+        py2_str_formatted = formatter(py2_str_value)
+        assert py2_str_formatted == expected
+
+
+# When unicode snapshots are saved in Python 2, there's no easy way to generate
+# a clean unicode_literals repr that doesn't use escape sequences. But the
+# resulting snapshots are still valid on Python 3 (and vice versa).
+@pytest.mark.parametrize("text_value, expected_py3, expected_py2", [
+    ("encodage précis", "'encodage précis'", "'encodage pr\\xe9cis'"),
+    ("精确的编码", "'精确的编码'", "'\\u7cbe\\u786e\\u7684\\u7f16\\u7801'"),
+    # backslash [unicode repr can't just be `"u'{}'".format(value)`]
+    ("omvänt\\snedstreck", "'omvänt\\\\snedstreck'", "'omv\\xe4nt\\\\snedstreck'"),
+    # multiline
+    ("ett\ntvå\n", "'''ett\ntvå\n'''", "'''ett\ntv\\xe5\n'''"),
+])
+def test_non_ascii_text_formatting(text_value, expected_py3, expected_py2):
+    expected = expected_py2 if six.PY2 else expected_py3
+    formatter = Formatter()
+    formatted = formatter(text_value)
+    assert formatted == expected


### PR DESCRIPTION
Generating snapshots on Python 2 would create unparseable snapshot
files for unicode text containing newlines.

Fixes #44.

Includes @tupy's PR #39 to fix non-ASCII character handling in single-line strings.
