### PR TITLE
Set up tox

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal = 1
 
 [flake8]
-exclude = snapshots
+exclude = snapshots .tox
 max-line-length = 120
 
 [tool:pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,31 @@
+[tox]
+envlist =
+  lint
+  py{27,34,35,36}
+
+[testenv]
+# pip install -e .[test]
+usedevelop = True
+extras = test
+commands =
+  py.test --cov=snapshottest tests examples/pytest
+  # Run Pytest Example
+  py.test examples/pytest
+  # Run Unittest Example
+  python examples/unittest/test_demo.py
+  # Run nose
+  nosetests examples/unittest
+  # Run django. since the test is dynamic it should fail without the update flag
+  bash -c 'cd examples/django_project && python manage.py test --snapshot-update'
+whitelist_externals =
+  bash
+passenv =
+  CONTINUOUS_INTEGRATION
+
+[testenv:lint]
+basepython = python3
+skip_install = True
+deps =
+    flake8
+commands =
+    flake8


### PR DESCRIPTION
Allow use of tox to simplify testing multiple Python versions.

The test matrix (tox envlist) and commands are largely copied directly
from .travis.yml.
