### PR TITLE
Fix formatter for `GenericRepr`

### DIFF
--- a/snapshottest/formatter.py
+++ b/snapshottest/formatter.py
@@ -4,7 +4,7 @@ from .formatters import default_formatters
 class Formatter(object):
     formatters = default_formatters()
 
-    def __init__(self, imports=None):
+    def __init__(self, imports):
         self.htchar = ' '*4
         self.lfchar = '\n'
         self.indent = 0

--- a/snapshottest/formatters.py
+++ b/snapshottest/formatters.py
@@ -97,7 +97,7 @@ class GenericFormatter(BaseFormatter):
 
     def format(self, value, indent, formatter):
         # `value` will always be a GenericRepr object because that's what `store` returns.
-        return repr(value)
+        return 'GenericRepr(%s)' % format_str(repr(value), indent, formatter)
 
     def get_imports(self):
         return [('snapshottest', 'GenericRepr')]

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 
 import pytest
 import six
+from datetime import date
+from collections import defaultdict
 
 from snapshottest.formatter import Formatter
 
@@ -20,9 +22,11 @@ from snapshottest.formatter import Formatter
     ("one\ntwo\n", "'''one\ntwo\n'''"),
     ("three\n'''quotes", "\"\"\"three\n'''quotes\"\"\""),
     ("so many\"\"\"\n'''quotes", "'''so many\"\"\"\n\\'\\'\\'quotes'''"),
+    # Generic representations
+    (date(2018, 1, 1), "GenericRepr('datetime.date(2018, 1, 1)')"),
 ])
 def test_text_formatting(text_value, expected):
-    formatter = Formatter()
+    formatter = Formatter(defaultdict(set))
     formatted = formatter(text_value)
     assert formatted == expected
 
@@ -48,6 +52,6 @@ def test_text_formatting(text_value, expected):
 ])
 def test_non_ascii_text_formatting(text_value, expected_py3, expected_py2):
     expected = expected_py2 if six.PY2 else expected_py3
-    formatter = Formatter()
+    formatter = Formatter(defaultdict(set))
     formatted = formatter(text_value)
     assert formatted == expected


### PR DESCRIPTION
Fixes https://github.com/syrusakbary/snapshottest/issues/57.

Edit: Not actually sure it does yet since I need to build more in-depth tests, but the formatter is better.

Edit 2: Still doesn't work because the formatter isn't used when asserting the snapshot on future executions - why use two different representations instead of just strings the whole way through? Is it for the test frameworks themselves?

Edit 3: The only way I see to make this work without reverting to using string diffs is to make a recursive normalizer that works alongside the formatter, and normalize before comparing values with the snapshot.