### PR TITLE
Hide empty test summary in Django

### DIFF
--- a/snapshottest/django.py
+++ b/snapshottest/django.py
@@ -40,12 +40,14 @@ class TestRunner(DiscoverRunner):
         return result
 
     def print_report(self):
-        print("\n" + self.separator1)
-        print('SnapshotTest summary')
-        print(self.separator2)
-        for line in reporting_lines('python manage.py test'):
-            print(line)
-        print(self.separator1)
+        lines = list(reporting_lines('python manage.py test'))
+        if lines:
+            print("\n" + self.separator1)
+            print('SnapshotTest summary')
+            print(self.separator2)
+            for line in lines:
+                print(line)
+            print(self.separator1)
 
 
 class TestCase(uTestCase, dTestCase):


### PR DESCRIPTION
Issue #61 

This is a small change to avoid clutter in the terminal when the Django test runner is used without there being any snapshot tests.  Currently, the below output is always displayed even when it is not relevant to the tests that are being run.
```sh
======================================================================
SnapshotTest summary
----------------------------------------------------------------------
======================================================================
```