### PR TITLE
Fix some bugs in GenericFormatter and collection formatters

### DIFF
--- a/examples/pytest/snapshots/snap_test_demo.py
+++ b/examples/pytest/snapshots/snap_test_demo.py
@@ -21,3 +21,23 @@ snapshots['test_file 1'] = FileSnapshot('snap_test_demo/test_file 1.txt')
 snapshots['test_multiple_files 1'] = FileSnapshot('snap_test_demo/test_multiple_files 1.txt')
 
 snapshots['test_multiple_files 2'] = FileSnapshot('snap_test_demo/test_multiple_files 2.txt')
+
+snapshots['test_nested_objects 1'] = {
+    'key': GenericRepr('#')
+}
+
+snapshots['test_nested_objects 2'] = [
+    GenericRepr('#')
+]
+
+snapshots['test_nested_objects 3'] = (
+    GenericRepr('#')
+,)
+
+snapshots['test_nested_objects 4'] = set([
+    GenericRepr('#')
+])
+
+snapshots['test_nested_objects 5'] = frozenset([
+    GenericRepr('#')
+])

--- a/examples/pytest/snapshots/snap_test_demo.py
+++ b/examples/pytest/snapshots/snap_test_demo.py
@@ -22,22 +22,28 @@ snapshots['test_multiple_files 1'] = FileSnapshot('snap_test_demo/test_multiple_
 
 snapshots['test_multiple_files 2'] = FileSnapshot('snap_test_demo/test_multiple_files 2.txt')
 
-snapshots['test_nested_objects 1'] = {
+snapshots['test_nested_objects dict'] = {
     'key': GenericRepr('#')
 }
 
-snapshots['test_nested_objects 2'] = [
+snapshots['test_nested_objects defaultdict'] = {
+    'key': [
+        GenericRepr('#')
+    ]
+}
+
+snapshots['test_nested_objects list'] = [
     GenericRepr('#')
 ]
 
-snapshots['test_nested_objects 3'] = (
+snapshots['test_nested_objects tuple'] = (
     GenericRepr('#')
 ,)
 
-snapshots['test_nested_objects 4'] = set([
+snapshots['test_nested_objects set'] = set([
     GenericRepr('#')
 ])
 
-snapshots['test_nested_objects 5'] = frozenset([
+snapshots['test_nested_objects frozenset'] = frozenset([
     GenericRepr('#')
 ])

--- a/examples/pytest/test_demo.py
+++ b/examples/pytest/test_demo.py
@@ -58,3 +58,25 @@ def test_multiple_files(snapshot, tmpdir):
     temp_file1 = tmpdir.join('example2.txt')
     temp_file1.write('Hello, world 2!')
     snapshot.assert_match(FileSnapshot(str(temp_file1)))
+
+
+class ObjectWithBadRepr(object):
+    def __repr__(self):
+        return "#"
+
+
+def test_nested_objects(snapshot):
+    obj = ObjectWithBadRepr()
+    
+    dict_ = {'key': obj}
+    list_ = [obj]
+    tuple_ = (obj,)
+    set_ = set((obj,))
+    frozenset_ = frozenset((obj,))
+    
+    snapshot.assert_match(dict_)
+    snapshot.assert_match(list_)
+    snapshot.assert_match(tuple_)
+    snapshot.assert_match(set_)
+    snapshot.assert_match(frozenset_)
+    

--- a/examples/pytest/test_demo.py
+++ b/examples/pytest/test_demo.py
@@ -67,16 +67,15 @@ class ObjectWithBadRepr(object):
 
 def test_nested_objects(snapshot):
     obj = ObjectWithBadRepr()
-    
+
     dict_ = {'key': obj}
     list_ = [obj]
     tuple_ = (obj,)
     set_ = set((obj,))
     frozenset_ = frozenset((obj,))
-    
+
     snapshot.assert_match(dict_)
     snapshot.assert_match(list_)
     snapshot.assert_match(tuple_)
     snapshot.assert_match(set_)
     snapshot.assert_match(frozenset_)
-    

--- a/examples/pytest/test_demo.py
+++ b/examples/pytest/test_demo.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from collections import defaultdict
+
 from snapshottest.file import FileSnapshot
 
 
@@ -69,13 +71,15 @@ def test_nested_objects(snapshot):
     obj = ObjectWithBadRepr()
 
     dict_ = {'key': obj}
+    defaultdict_ = defaultdict(list, [('key', [obj])])
     list_ = [obj]
     tuple_ = (obj,)
     set_ = set((obj,))
     frozenset_ = frozenset((obj,))
 
-    snapshot.assert_match(dict_)
-    snapshot.assert_match(list_)
-    snapshot.assert_match(tuple_)
-    snapshot.assert_match(set_)
-    snapshot.assert_match(frozenset_)
+    snapshot.assert_match(dict_, 'dict')
+    snapshot.assert_match(defaultdict_, 'defaultdict')
+    snapshot.assert_match(list_, 'list')
+    snapshot.assert_match(tuple_, 'tuple')
+    snapshot.assert_match(set_, 'set')
+    snapshot.assert_match(frozenset_, 'frozenset')

--- a/snapshottest/file.py
+++ b/snapshottest/file.py
@@ -47,7 +47,7 @@ class FileSnapshotFormatter(BaseFormatter):
     def format(self, value, indent, formatter):
         return repr(value)
 
-    def assert_value_matches_snapshot(self, test, test_value, snapshot_value):
+    def assert_value_matches_snapshot(self, test, test_value, snapshot_value, formatter):
         snapshot_path = os.path.join(test.module.snapshot_dir, snapshot_value.path)
         files_identical = filecmp.cmp(test_value.path, snapshot_path, shallow=False)
         assert files_identical, "Stored file differs from test file"

--- a/snapshottest/formatter.py
+++ b/snapshottest/formatter.py
@@ -19,6 +19,10 @@ class Formatter(object):
             self.imports[module].add(import_name)
         return formatter.format(value, indent, self)
 
+    def normalize(self, value):
+        formatter = self.get_formatter(value)
+        return formatter.normalize(value, self)
+
     @staticmethod
     def get_formatter(value):
         for formatter in Formatter.formatters:

--- a/snapshottest/formatters.py
+++ b/snapshottest/formatters.py
@@ -73,21 +73,27 @@ def format_dict(value, indent, formatter):
 
 
 def format_list(value, indent, formatter):
+    return '[%s]' % format_iterable(value, indent, formatter)
+
+
+def format_iterable(value, indent, formatter):
     items = [
         formatter.lfchar + formatter.htchar * (indent + 1) + formatter.format(item, indent + 1)
         for item in value
     ]
-    return '[%s]' % (','.join(items) + formatter.lfchar + formatter.htchar * indent)
+    return ','.join(items) + formatter.lfchar + formatter.htchar * indent
 
 
 def format_tuple(value, indent, formatter):
-    items = [
-        formatter.lfchar + formatter.htchar * (indent + 1) + formatter.format(item, indent + 1)
-        for item in value
-    ]
-    if len(items) == 1:
-        return '(%s,)' % (items[0] + formatter.lfchar + formatter.htchar * indent)
-    return '(%s)' % (','.join(items) + formatter.lfchar + formatter.htchar * indent)
+    return '(%s%s' % (format_iterable(value, indent, formatter), ',)' if len(value) == 1 else ")")
+
+
+def format_set(value, indent, formatter):
+    return 'set([%s])' % format_iterable(value, indent, formatter)
+
+
+def format_frozenset(value, indent, formatter):
+    return 'frozenset([%s])' % format_iterable(value, indent, formatter)
 
 
 class GenericFormatter(BaseFormatter):
@@ -117,6 +123,8 @@ def default_formatters():
         TypeFormatter(dict, format_dict),
         TypeFormatter(tuple, format_tuple),
         TypeFormatter(list, format_list),
+        TypeFormatter(set, format_set),
+        TypeFormatter(frozenset, format_frozenset),
         TypeFormatter(six.string_types, format_str),
         TypeFormatter((int, float, complex, bool, bytes, set, frozenset), format_std_type),
         GenericFormatter()

--- a/snapshottest/formatters.py
+++ b/snapshottest/formatters.py
@@ -73,10 +73,10 @@ def format_dict(value, indent, formatter):
 
 
 def format_list(value, indent, formatter):
-    return '[%s]' % format_iterable(value, indent, formatter)
+    return '[%s]' % format_sequence(value, indent, formatter)
 
 
-def format_iterable(value, indent, formatter):
+def format_sequence(value, indent, formatter):
     items = [
         formatter.lfchar + formatter.htchar * (indent + 1) + formatter.format(item, indent + 1)
         for item in value
@@ -85,15 +85,15 @@ def format_iterable(value, indent, formatter):
 
 
 def format_tuple(value, indent, formatter):
-    return '(%s%s' % (format_iterable(value, indent, formatter), ',)' if len(value) == 1 else ")")
+    return '(%s%s' % (format_sequence(value, indent, formatter), ',)' if len(value) == 1 else ")")
 
 
 def format_set(value, indent, formatter):
-    return 'set([%s])' % format_iterable(value, indent, formatter)
+    return 'set([%s])' % format_sequence(value, indent, formatter)
 
 
 def format_frozenset(value, indent, formatter):
-    return 'frozenset([%s])' % format_iterable(value, indent, formatter)
+    return 'frozenset([%s])' % format_sequence(value, indent, formatter)
 
 
 class GenericFormatter(BaseFormatter):

--- a/snapshottest/formatters.py
+++ b/snapshottest/formatters.py
@@ -1,4 +1,5 @@
 import six
+from collections import defaultdict
 
 from .sorted_dict import SortedDict
 from .generic_repr import GenericRepr
@@ -40,6 +41,13 @@ class CollectionFormatter(TypeFormatter):
     def normalize(self, value, formatter):
         iterator = iter(value.items()) if isinstance(value, dict) else iter(value)
         return value.__class__(formatter.normalize(item) for item in iterator)
+
+
+class DefaultDictFormatter(TypeFormatter):
+    def normalize(self, value, formatter):
+        return defaultdict(
+            value.default_factory, (formatter.normalize(item) for item in value.items())
+        )
 
 
 def trepr(s):
@@ -132,6 +140,7 @@ class GenericFormatter(BaseFormatter):
 def default_formatters():
     return [
         TypeFormatter(type(None), format_none),
+        DefaultDictFormatter(defaultdict, format_dict),
         CollectionFormatter(dict, format_dict),
         CollectionFormatter(tuple, format_tuple),
         CollectionFormatter(list, format_list),

--- a/snapshottest/formatters.py
+++ b/snapshottest/formatters.py
@@ -98,7 +98,8 @@ class GenericFormatter(BaseFormatter):
         return GenericRepr.from_value(value)
 
     def format(self, value, indent, formatter):
-        # `value` will always be a GenericRepr object because that's what `store` returns.
+        if not isinstance(value, GenericRepr):
+            value = GenericRepr.from_value(value)
         return repr(value)
 
     def get_imports(self):

--- a/snapshottest/formatters.py
+++ b/snapshottest/formatters.py
@@ -111,7 +111,7 @@ class GenericFormatter(BaseFormatter):
 
     def store(self, test, value):
         return GenericRepr.from_value(value)
-    
+
     def normalize(self, value, formatter):
         return GenericRepr.from_value(value)
 

--- a/snapshottest/formatters.py
+++ b/snapshottest/formatters.py
@@ -85,6 +85,8 @@ def format_tuple(value, indent, formatter):
         formatter.lfchar + formatter.htchar * (indent + 1) + formatter.format(item, indent + 1)
         for item in value
     ]
+    if len(items) == 1:
+        return '(%s,)' % (items[0] + formatter.lfchar + formatter.htchar * indent)
     return '(%s)' % (','.join(items) + formatter.lfchar + formatter.htchar * indent)
 
 

--- a/snapshottest/generic_repr.py
+++ b/snapshottest/generic_repr.py
@@ -7,7 +7,7 @@ class GenericRepr(object):
 
     def __eq__(self, other):
         return isinstance(other, GenericRepr) and self.representation == other.representation
-    
+
     def __hash__(self):
         return hash(self.representation)
 

--- a/snapshottest/generic_repr.py
+++ b/snapshottest/generic_repr.py
@@ -7,6 +7,9 @@ class GenericRepr(object):
 
     def __eq__(self, other):
         return isinstance(other, GenericRepr) and self.representation == other.representation
+    
+    def __hash__(self):
+        return hash(self.representation)
 
     @staticmethod
     def from_value(value):

--- a/snapshottest/module.py
+++ b/snapshottest/module.py
@@ -226,7 +226,7 @@ class SnapshotTest(object):
 
     def assert_value_matches_snapshot(self, test_value, snapshot_value):
         formatter = Formatter.get_formatter(test_value)
-        formatter.assert_value_matches_snapshot(self, test_value, snapshot_value)
+        formatter.assert_value_matches_snapshot(self, test_value, snapshot_value, Formatter())
 
     def assert_equals(self, value, snapshot):
         assert value == snapshot

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -35,14 +35,14 @@ class TestPyTestSnapShotTest:
 
 
 def test_pytest_snapshottest_property_test_name(pytest_snapshot_test):
-        pytest_snapshot_test.assert_match('counter')
-        assert pytest_snapshot_test.test_name == \
-            'test_pytest_snapshottest_property_test_name 1'
+    pytest_snapshot_test.assert_match('counter')
+    assert pytest_snapshot_test.test_name == \
+        'test_pytest_snapshottest_property_test_name 1'
 
-        pytest_snapshot_test.assert_match('named', 'named_test')
-        assert pytest_snapshot_test.test_name == \
-            'test_pytest_snapshottest_property_test_name named_test'
+    pytest_snapshot_test.assert_match('named', 'named_test')
+    assert pytest_snapshot_test.test_name == \
+        'test_pytest_snapshottest_property_test_name named_test'
 
-        pytest_snapshot_test.assert_match('counter')
-        assert pytest_snapshot_test.test_name == \
-            'test_pytest_snapshottest_property_test_name 2'
+    pytest_snapshot_test.assert_match('counter')
+    assert pytest_snapshot_test.test_name == \
+        'test_pytest_snapshottest_property_test_name 2'

--- a/tests/test_snapshot_test.py
+++ b/tests/test_snapshot_test.py
@@ -67,6 +67,7 @@ SNAPSHOTABLE_VALUES = [
     ["a", "b", "c"],  # list
     {"a", "b", "c"},  # set
     ("a", "b", "c"),  # tuple
+    ("a",),           # tuple only have one element
 
     # Falsy values:
     None,


### PR DESCRIPTION
After upgrading to 0b4656a I noticed snapshottest was saving the repr of objects that should be wrapped inside a `GenericRepr`.

After bisecting I found out that b78eb52 relied on the assumption that the `value` argument of `GenericFormatter.format` is always the return of `GenericFormatter.store`, which isn't the case while formatting the items inside dicts, lists and tuples.

Also, after #54 removed `PrettyDiff` usage in `SnapshotTest.assert_match` snapshottest stopped "normalizing" the value before comparing, so it was comparing `GenericRepr` with the actual represented objects.

This PR fixes these issues and also improves support for `defaultdict`, `set` and `frozenset`. It is based on #72 because I needed this fix. (thanks, @lucemia!)

Closes #71
cc @matangover