### PR TITLE
Proposal: use Makefile to install deps, test, lint, etc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,23 +6,12 @@ python:
 - 3.5
 - 3.6
 cache: pip
-install:
-- pip install -e .[test]
-script:
-- py.test --cov=snapshottest tests examples/pytest
-# Run Pytest Example
-- py.test examples/pytest
-# Run Unittest Example
-- python examples/unittest/test_demo.py
-# Run nose
-- nosetests examples/unittest
-# Run Django Example
-- cd examples/django_project && python manage.py test
+install: make install
+script: make test
 after_success:
 - coveralls
 matrix:
   fast_finish: true
   include:
   - python: '2.7'
-    install: pip install flake8
-    script: flake8
+    script: make lint

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+all: install test README.rst
+
+.PHONY: install
+install:
+	pip install -e ".[test]"
+	pip install flake8
+
+.PHONY: test
+test:
+# Run Pytest tests (including examples)
+	py.test --cov=snapshottest tests examples/pytest
+
+# Run Unittest Example
+	python examples/unittest/test_demo.py
+
+# Run nose
+	nosetests examples/unittest
+
+# Run Django Example
+	cd examples/django_project && python manage.py test
+
+.PHONY: lint
+lint:
+	flake8
+
+%.rst: %.md
+	pandoc $^ --from markdown --to rst -s -o $@

--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ Snapshot testing is a way to test your APIs without writing actual test cases.
 2. You have a set of snapshots for your API endpoints.
 3. Once you add a new feature, you can generate *automatically* new snapshots for the updated API.
 
-
-
-<p align="center"><a href="https://asciinema.org/a/5l6neenlh22xw7him5upj3sbg" target="_blank"><img src="https://asciinema.org/a/5l6neenlh22xw7him5upj3sbg.png" width="400" height="280" /></a></p>
-
 ## Installation
 
     $ pip install snapshottest
@@ -78,22 +74,31 @@ Check the [Django example](https://github.com/syrusakbary/snapshottest/tree/mast
 
 # Contributing
 
-After cloning this repo, ensure dependencies are installed by running:
+After cloning this repo and configuring a virtualenv for snapshottest (optional, but highly recommended), ensure dependencies are installed by running:
 
 ```sh
-pip install -e ".[test]"
+make install
 ```
 
 After developing, the full test suite can be evaluated by running:
 
 ```sh
-py.test
+make lint
+# and
+make test
 ```
 
+If you change this `README.md`, remember to update its `README.rst` counterpart (used by PyPI), which can be done by running:
+
+```
+make README.rst
+```
+
+For this last step you'll need to have `pandoc` installed in your machine.
 
 # Notes
 
-This package is heavily insipired in [jest snapshot testing](https://facebook.github.io/jest/docs/snapshot-testing.html).
+This package is heavily inspired in [jest snapshot testing](https://facebook.github.io/jest/docs/snapshot-testing.html).
 
 # Reasons for use this package
 

--- a/README.rst
+++ b/README.rst
@@ -9,14 +9,6 @@ cases.
 3. Once you add a new feature, you can generate *automatically* new
    snapshots for the updated API.
 
-.. raw:: html
-
-   <p align="center">
-
-.. raw:: html
-
-   </p>
-
 Installation
 ------------
 
@@ -95,22 +87,33 @@ example <https://github.com/syrusakbary/snapshottest/tree/master/examples/django
 Contributing
 ============
 
-After cloning this repo, ensure dependencies are installed by running:
+After cloning this repo and configuring a virtualenv for snapshottest
+(optional, but highly recommended), ensure dependencies are installed by
+running:
 
 .. code:: sh
 
-    pip install -e ".[test]"
+    make install
 
 After developing, the full test suite can be evaluated by running:
 
 .. code:: sh
 
-    py.test
+    make lint
+    # and
+    make test
+
+If you change this ``README.md``, you'll need to have pandoc installed to update its ``README.rst`` counterpart (used by PyPI),
+which can be done by running:
+
+::
+
+    make README.rst
 
 Notes
 =====
 
-This package is heavily insipired in `jest snapshot
+This package is heavily inspired in `jest snapshot
 testing <https://facebook.github.io/jest/docs/snapshot-testing.html>`__.
 
 Reasons for use this package

--- a/bin/convert_documentation
+++ b/bin/convert_documentation
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-pandoc README.md --from markdown --to rst -s -o README.rst

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -35,14 +35,14 @@ class TestPyTestSnapShotTest:
 
 
 def test_pytest_snapshottest_property_test_name(pytest_snapshot_test):
-        pytest_snapshot_test.assert_match('counter')
-        assert pytest_snapshot_test.test_name == \
-            'test_pytest_snapshottest_property_test_name 1'
+    pytest_snapshot_test.assert_match('counter')
+    assert pytest_snapshot_test.test_name == \
+        'test_pytest_snapshottest_property_test_name 1'
 
-        pytest_snapshot_test.assert_match('named', 'named_test')
-        assert pytest_snapshot_test.test_name == \
-            'test_pytest_snapshottest_property_test_name named_test'
+    pytest_snapshot_test.assert_match('named', 'named_test')
+    assert pytest_snapshot_test.test_name == \
+        'test_pytest_snapshottest_property_test_name named_test'
 
-        pytest_snapshot_test.assert_match('counter')
-        assert pytest_snapshot_test.test_name == \
-            'test_pytest_snapshottest_property_test_name 2'
+    pytest_snapshot_test.assert_match('counter')
+    assert pytest_snapshot_test.test_name == \
+        'test_pytest_snapshottest_property_test_name 2'

--- a/tox.ini
+++ b/tox.ini
@@ -4,20 +4,12 @@ envlist =
   py{27,34,35,36}
 
 [testenv]
-# pip install -e .[test]
 usedevelop = True
 extras = test
 commands =
-  py.test --cov=snapshottest tests examples/pytest
-  # Run Pytest Example
-  py.test examples/pytest
-  # Run Unittest Example
-  python examples/unittest/test_demo.py
-  # Run nose
-  nosetests examples/unittest
-  # Run Django Example
-  bash -c 'cd examples/django_project && python manage.py test'
+  make test
 whitelist_externals =
+  make
   bash
 passenv =
   CONTINUOUS_INTEGRATION


### PR DESCRIPTION
This eliminates repetition between `.travis.yml`, `tox.ini` and `README.md`, while also making life a little easier for contributors.