### PR TITLE
Fix pytest parametrize for multiline strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+venv/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal = 1
 
 [flake8]
-exclude = snapshots .tox
+exclude = snapshots .tox venv
 max-line-length = 120
 
 [tool:pytest]

--- a/snapshottest/pytest.py
+++ b/snapshottest/pytest.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import pytest
+import re
 
 from .module import SnapshotModule, SnapshotTest
 from .diff import PrettyDiff
@@ -40,9 +41,10 @@ class PyTestSnapshotTest(SnapshotTest):
     @property
     def test_name(self):
         cls_name = getattr(self.request.node.cls, '__name__', '')
+        flattened_node_name = re.sub(r"\s+", " ", self.request.node.name.replace(r"\n", " "))
         return '{}{} {}'.format(
             '{}.'.format(cls_name) if cls_name else '',
-            self.request.node.name,
+            flattened_node_name,
             self.curr_snapshot
         )
 

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -46,3 +46,23 @@ def test_pytest_snapshottest_property_test_name(pytest_snapshot_test):
     pytest_snapshot_test.assert_match('counter')
     assert pytest_snapshot_test.test_name == \
         'test_pytest_snapshottest_property_test_name 2'
+
+
+@pytest.mark.parametrize('arg', ['single line string'])
+def test_pytest_snapshottest_property_test_name_parametrize_singleline(pytest_snapshot_test, arg):
+    pytest_snapshot_test.assert_match('counter')
+    assert pytest_snapshot_test.test_name == \
+        'test_pytest_snapshottest_property_test_name_parametrize_singleline[single line string] 1'
+
+
+@pytest.mark.parametrize('arg', [
+    '''
+    multi
+    line
+    string
+    '''
+])
+def test_pytest_snapshottest_property_test_name_parametrize_multiline(pytest_snapshot_test, arg):
+    pytest_snapshot_test.assert_match('counter')
+    assert pytest_snapshot_test.test_name == \
+        'test_pytest_snapshottest_property_test_name_parametrize_multiline[ multi line string ] 1'


### PR DESCRIPTION
When using `pytest.parametrize` with multiline strings, the new line string literal `\n` causes the test name to change on each test run, which causes unexpected behavior.

Here's an example given the following script `script.py`:

    import pytest

    def return_one(s):
        return 1

    @pytest.mark.parametrize(
        "s",
        [
            "singleline",
            """
            some
            multiline
            string
            """,
        ],
    )
    def test_return_one(snapshot, s):
        result = return_one(s)
        snapshot.assert_match(result)

When running `pytest script.py` I get `2 snapshots written` which look like this:

    snapshots['test_return_one[singleline] 1'] = 1

    snapshots['test_return_one[\n        some\n        multiline\n        string\n        ] 1'] = 1

When running `pytest script.py` I get `1 snapshots written` and `1 snapshots deprecated` which returns an invalid python file (notice the malformed second test):

    snapshots['test_return_one[singleline] 1'] = 1

    snapshots['test_return_one[
                    some
                    multiline
                    string
                    ] 1'] = 1

    snapshots['test_return_one[\n        some\n        multiline\n        string\n        ] 1'] = 1

This fix will return the following snapshots on each test run:

    snapshots['test_return_one[singleline] 1'] = 1

    snapshots['test_return_one[ some multiline string ] 1'] = 1

Using pytest parametrize for multiline strings is specifically important when using snapshottest with [graphene](https://github.com/graphql-python/graphene). There should be countless other use cases besides that.