### PR TITLE
PEP-508 version range for fastdiff

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'nose.plugins.0.10':
         ['snapshottest = snapshottest.nose:SnapshotTestPlugin']
     },
-    install_requires=['six>=1.10.0', 'termcolor', 'fastdiff>=0.1.4<1'],
+    install_requires=['six>=1.10.0', 'termcolor', 'fastdiff>=0.1.4,<1'],
     tests_require=tests_require,
     extras_require={
         'test': tests_require,


### PR DESCRIPTION
The version range for fastdiff in setup.py did not comply with [PEP-508](https://www.python.org/dev/peps/pep-0508/)

