### PR TITLE
Fixes #65. SortedDict now handles keys other than strings.

### DIFF
--- a/snapshottest/diff.py
+++ b/snapshottest/diff.py
@@ -25,7 +25,7 @@ class PrettyDiff(object):
         self.pretty = Formatter()
         self.snapshottest = snapshottest
         if isinstance(obj, dict):
-            obj = SortedDict(**obj)
+            obj = SortedDict(obj)
         self.obj = self.pretty(obj)
 
     def __eq__(self, other):

--- a/snapshottest/formatters.py
+++ b/snapshottest/formatters.py
@@ -80,7 +80,7 @@ def format_std_type(value, indent, formatter):
 
 
 def format_dict(value, indent, formatter):
-    value = SortedDict(**value)
+    value = SortedDict(value)
     items = [
         formatter.lfchar + formatter.htchar * (indent + 1) + formatter.format(key, indent) + ': ' +
         formatter.format(value[key], indent + 1)

--- a/snapshottest/sorted_dict.py
+++ b/snapshottest/sorted_dict.py
@@ -2,12 +2,18 @@ from collections import OrderedDict
 
 
 class SortedDict(OrderedDict):
-    def __init__(self, **kwargs):
+
+    def __init__(self, values):
         super(SortedDict, self).__init__()
 
-        for key, value in sorted(kwargs.items()):
+        try:
+            sorted_items = sorted(values.items())
+        except TypeError:
+            # Enums are not sortable
+            sorted_items = values.items()
+        for key, value in sorted_items:
             if isinstance(value, dict):
-                self[key] = SortedDict(**value)
+                self[key] = SortedDict(value)
             elif isinstance(value, list):
                 self[key] = self._sort_list(value)
             else:
@@ -16,7 +22,7 @@ class SortedDict(OrderedDict):
     def _sort_list(self, value):
         def sort(val):
             if isinstance(val, dict):
-                return SortedDict(**val)
+                return SortedDict(val)
             elif isinstance(val, list):
                 return self._sort_list(val)
             else:

--- a/tests/test_sorted_dict.py
+++ b/tests/test_sorted_dict.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import enum
+
+import pytest
+
+from snapshottest.sorted_dict import SortedDict
+
+
+@pytest.mark.parametrize("key, value", [
+    ('key1', 'value'),
+    ('key2', 42),
+    ('key3', ['value']),
+    ('key4', [['value']]),
+    ('key5', {'key': 'value'}),
+    ('key6', [{'key': 'value'}]),
+    ('key7', {'key': ['value']}),
+    ('key8', [{'key': ['value']}]),
+])
+def test_sorted_dict(key, value):
+    dic = dict([(key, value)])
+    assert SortedDict(dic)[key] == value
+
+
+def test_sorted_dict_string_key():
+    value = ('key', 'value')
+    dic = dict([value])
+    assert SortedDict(dic)[value[0]] == value[1]
+
+
+def test_sorted_dict_int_key():
+    value = (0, 'value')
+    dic = dict([value])
+    assert SortedDict(dic)[value[0]] == value[1]
+
+
+def test_sorted_dict_intenum():
+
+    class Fruit(enum.IntEnum):
+        APPLE = 1
+        ORANGE = 2
+
+    dic = {
+        Fruit.APPLE: 100,
+        Fruit.ORANGE: 400,
+    }
+    assert SortedDict(dic)[Fruit.APPLE] == dic[Fruit.APPLE]
+    assert SortedDict(dic)[Fruit.ORANGE] == dic[Fruit.ORANGE]
+
+
+def test_sorted_dict_enum():
+
+    class Fruit(enum.Enum):
+        APPLE = 1
+        ORANGE = 2
+
+    dic = {
+        Fruit.APPLE: 100,
+        Fruit.ORANGE: 400,
+    }
+    assert SortedDict(dic)[Fruit.APPLE] == dic[Fruit.APPLE]
+    assert SortedDict(dic)[Fruit.ORANGE] == dic[Fruit.ORANGE]
+
+
+def test_sorted_dict_enum_value():
+
+    class Fruit(enum.Enum):
+        APPLE = 1
+        ORANGE = 2
+
+    value = ("fruit", Fruit)
+    dic = dict([value])
+    assert SortedDict(dic)[value[0]] == value[1]
+
+
+def test_sorted_dict_enum_key():
+
+    class Fruit(enum.Enum):
+        APPLE = 1
+        ORANGE = 2
+
+    value = (Fruit, "fruit")
+    dic = dict([value])
+    assert SortedDict(dic)[value[0]] == value[1]


### PR DESCRIPTION
`SortedDict` only allowed named arguments as parameters in the form of `**kwargs`, hence limiting the creation of `SortedDict`s with keys other than strings (fixes #65). This PR replaces `**kwargs` as the main argument to build a `SortedDict` and uses instead a regular dict `values` that can contain anything a regular Python dict could.

The only significant change is that to instantiate a new `SortedDict` now, you don't need to pass in the named arguments, `SortedDict(**value)`, but just the variable, `SortedDict(value)`.

Tests have been added for the `SortedDict` class.