### PR TITLE
Don't allow missing snapshots without --snapshot-update

### DIFF
--- a/snapshottest/module.py
+++ b/snapshottest/module.py
@@ -24,6 +24,7 @@ class SnapshotModule(object):
         self.imports = defaultdict(set)
         self.visited_snapshots = set()
         self.new_snapshots = set()
+        self.missing_snapshots = set()
         self.failed_snapshots = set()
         self.imports['snapshottest'].add('Snapshot')
 
@@ -90,6 +91,10 @@ class SnapshotModule(object):
         return cls.stats_for_module(lambda module: len(module.new_snapshots))
 
     @classmethod
+    def stats_missing_snapshots(cls):
+        return cls.stats_for_module(lambda module: len(module.missing_snapshots))
+
+    @classmethod
     def stats_failed_snapshots(cls):
         return cls.stats_for_module(lambda module: len(module.failed_snapshots))
 
@@ -129,6 +134,9 @@ class SnapshotModule(object):
 
     def mark_failed(self, key):
         return self.failed_snapshots.add(key)
+
+    def mark_missing(self, key):
+        return self.missing_snapshots.add(key)
 
     @property
     def snapshot_dir(self):
@@ -219,6 +227,9 @@ class SnapshotTest(object):
     def fail(self):
         self.module.mark_failed(self.test_name)
 
+    def missing(self):
+        self.module.mark_missing(self.test_name)
+
     def store(self, data):
         formatter = Formatter.get_formatter(data)
         data = formatter.store(self, data)
@@ -231,16 +242,19 @@ class SnapshotTest(object):
     def assert_equals(self, value, snapshot):
         assert value == snapshot
 
-    def assert_match(self, value, name=''):
+    def assert_match(self, value, name="", update=False):
         self.curr_snapshot = name or self.snapshot_counter
         self.visit()
-        if self.update:
+        if self.update or update:
             self.store(value)
         else:
             try:
                 prev_snapshot = self.module[self.test_name]
             except SnapshotNotFound:
-                self.store(value)  # first time this test has been seen
+                # There is no snapshot for this test, run with --snapshot-update
+                # to create it
+                self.missing()
+                raise
             else:
                 try:
                     self.assert_value_matches_snapshot(value, prev_snapshot)

--- a/snapshottest/reporting.py
+++ b/snapshottest/reporting.py
@@ -7,11 +7,17 @@ from .module import SnapshotModule
 def reporting_lines(testing_cli):
     successful_snapshots = SnapshotModule.stats_successful_snapshots()
     bold = ['bold']
+    new_snapshots = SnapshotModule.stats_new_snapshots()
     if successful_snapshots:
         yield (
             colored('{} snapshots passed', attrs=bold) + '.'
         ).format(successful_snapshots)
-    new_snapshots = SnapshotModule.stats_new_snapshots()
+    missing_snapshots = SnapshotModule.stats_missing_snapshots()
+    if missing_snapshots[0]:
+        yield (
+            colored("{} snapshots missing", "red", attrs=bold)
+            + " in {} test suites. Run with `--snapshot-update` to create them."
+        ).format(*missing_snapshots)
     if new_snapshots[0]:
         yield (
             colored('{} snapshots written', 'green', attrs=bold) + ' in {} test suites.'

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -21,36 +21,36 @@ def pytest_snapshot_test(request, _apply_options):
 
 class TestPyTestSnapShotTest:
     def test_property_test_name(self, pytest_snapshot_test):
-        pytest_snapshot_test.assert_match('counter')
+        pytest_snapshot_test.assert_match('counter', update=True)
         assert pytest_snapshot_test.test_name == \
             'TestPyTestSnapShotTest.test_property_test_name 1'
 
-        pytest_snapshot_test.assert_match('named', 'named_test')
+        pytest_snapshot_test.assert_match('named', 'named_test', update=True)
         assert pytest_snapshot_test.test_name == \
             'TestPyTestSnapShotTest.test_property_test_name named_test'
 
-        pytest_snapshot_test.assert_match('counter')
+        pytest_snapshot_test.assert_match('counter', update=True)
         assert pytest_snapshot_test.test_name == \
             'TestPyTestSnapShotTest.test_property_test_name 2'
 
 
 def test_pytest_snapshottest_property_test_name(pytest_snapshot_test):
-    pytest_snapshot_test.assert_match('counter')
+    pytest_snapshot_test.assert_match('counter', update=True)
     assert pytest_snapshot_test.test_name == \
         'test_pytest_snapshottest_property_test_name 1'
 
-    pytest_snapshot_test.assert_match('named', 'named_test')
+    pytest_snapshot_test.assert_match('named', 'named_test', update=True)
     assert pytest_snapshot_test.test_name == \
         'test_pytest_snapshottest_property_test_name named_test'
 
-    pytest_snapshot_test.assert_match('counter')
+    pytest_snapshot_test.assert_match('counter', update=True)
     assert pytest_snapshot_test.test_name == \
         'test_pytest_snapshottest_property_test_name 2'
 
 
 @pytest.mark.parametrize('arg', ['single line string'])
 def test_pytest_snapshottest_property_test_name_parametrize_singleline(pytest_snapshot_test, arg):
-    pytest_snapshot_test.assert_match('counter')
+    pytest_snapshot_test.assert_match('counter', update=True)
     assert pytest_snapshot_test.test_name == \
         'test_pytest_snapshottest_property_test_name_parametrize_singleline[single line string] 1'
 
@@ -63,6 +63,6 @@ def test_pytest_snapshottest_property_test_name_parametrize_singleline(pytest_sn
     '''
 ])
 def test_pytest_snapshottest_property_test_name_parametrize_multiline(pytest_snapshot_test, arg):
-    pytest_snapshot_test.assert_match('counter')
+    pytest_snapshot_test.assert_match('counter', update=True)
     assert pytest_snapshot_test.test_name == \
         'test_pytest_snapshottest_property_test_name_parametrize_multiline[ multi line string ] 1'

--- a/tests/test_snapshot_test.py
+++ b/tests/test_snapshot_test.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import pytest
 
 from snapshottest.module import SnapshotModule, SnapshotTest
+from snapshottest.error import SnapshotNotFound
 
 
 class GenericSnapshotTest(SnapshotTest):
@@ -86,7 +87,7 @@ SNAPSHOTABLE_VALUES = [
 @pytest.mark.parametrize("value", SNAPSHOTABLE_VALUES, ids=repr)
 def test_snapshot_matches_itself(snapshot_test, value):
     # first run stores the value as the snapshot
-    snapshot_test.assert_match(value)
+    snapshot_test.assert_match(value, update=True)
     assert_snapshot_test_succeeded(snapshot_test)
 
     # second run should compare stored snapshot and also succeed
@@ -103,7 +104,7 @@ def test_snapshot_matches_itself(snapshot_test, value):
 ])
 def test_snapshot_does_not_match_other_values(snapshot_test, value, other_value):
     # first run stores the value as the snapshot
-    snapshot_test.assert_match(value)
+    snapshot_test.assert_match(value, update=True)
     assert_snapshot_test_succeeded(snapshot_test)
 
     # second run tries to match other_value, should fail
@@ -111,3 +112,8 @@ def test_snapshot_does_not_match_other_values(snapshot_test, value, other_value)
     with pytest.raises(AssertionError):
         snapshot_test.assert_match(other_value)
     assert_snapshot_test_failed(snapshot_test)
+
+def test_first_run_without_snapshots_fails(snapshot_test):
+    with pytest.raises(SnapshotNotFound):
+        snapshot_test.assert_match('foo', name="no_snapshot_exists_test")
+    assert snapshot_test.module.missing_snapshots == set(["test_mocked no_snapshot_exists_test"])


### PR DESCRIPTION
Fixes #73 

Possibly should only be included in a new major version so that it doesn't break people's CI.