### PR TITLE
Use newer pytest to fix CI under Python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 with open('README.rst') as f:
     readme = f.read()
 
-tests_require = ['six', 'pytest>=3.1.0', 'pytest-cov', 'nose', 'django>=1.10.6']
+tests_require = ['six', 'pytest>=4.6', 'pytest-cov', 'nose', 'django>=1.10.6']
 
 setup(
     name='snapshottest',


### PR DESCRIPTION
```
pytest-cov 2.10.0 has requirement pytest>=4.6, but you'll have pytest 4.1.0 which is incompatible.
```