### PR TITLE
Fix publish command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,4 @@ clean:
 .PHONY: publish
 publish: clean
 	python3 setup.py sdist bdist_wheel
-	python2 setup.py bdist_wheel
 	twine upload dist/*


### PR DESCRIPTION
The wheel generated by Python 2 seems to be incompatible with
long_description_content_type. However the wheel generated by Python 3
seems to support Python 2 as well. So I think this is generating wheels
for both platforms.