### PR TITLE
Adopt black for code formatting 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
 - 3.6
 - 3.7
 - 3.8
-- 3.9
 cache: pip
 install: make install
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ matrix:
   fast_finish: true
   include:
   - python: '3.8'
+    install: pip install flake8
     script: make lint
   include:
   - python: '3.8'
+    install: pip install black==20.8b1
     script: make format

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 - 3.6
 - 3.7
 - 3.8
+- 3.9
 cache: pip
 install: make install
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,8 @@ after_success:
 matrix:
   fast_finish: true
   include:
-  - python: '2.7'
+  - python: '3.8'
     script: make lint
+  include:
+  - python: '3.8'
+    script: make format

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: install test
 .PHONY: install
 install:
 	pip install -e ".[test]"
-	pip install flake8
+	pip install flake8 black==20.8b1
 
 .PHONY: test
 test:
@@ -22,6 +22,14 @@ test:
 .PHONY: lint
 lint:
 	flake8
+
+.PHONY: format
+format:
+	black --check setup.py snapshottest tests examples --exclude 'snapshots\/snap_.*.py$$'
+
+.PHONY: format-fix
+format-fix:
+	black setup.py snapshottest tests examples --exclude 'snapshots\/snap_.*.py$$'
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ all: install test
 .PHONY: install
 install:
 	pip install -e ".[test]"
-	pip install flake8 black==20.8b1
 
 .PHONY: test
 test:

--- a/examples/django_project/django_project/settings.py
+++ b/examples/django_project/django_project/settings.py
@@ -75,7 +75,11 @@ TEST_RUNNER = "snapshottest.django.TestRunner"
 # Database
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
-DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3",}}
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+    }
+}
 
 
 # Password validation
@@ -85,9 +89,15 @@ AUTH_PASSWORD_VALIDATORS = [
     {
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
-    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",},
-    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",},
-    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",},
+    {
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
+    },
 ]
 
 

--- a/examples/django_project/django_project/settings.py
+++ b/examples/django_project/django_project/settings.py
@@ -20,7 +20,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '$5@im(@s1+p9a&ob#1osrq%*-sue%90o6q*cf0)$h@urtql^4@'
+SECRET_KEY = "$5@im(@s1+p9a&ob#1osrq%*-sue%90o6q*cf0)$h@urtql^4@"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -31,55 +31,51 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'lists'
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "lists",
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-ROOT_URLCONF = 'django_project.urls'
+ROOT_URLCONF = "django_project.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     },
 ]
 
-WSGI_APPLICATION = 'django_project.wsgi.application'
+WSGI_APPLICATION = "django_project.wsgi.application"
 
-TEST_RUNNER = 'snapshottest.django.TestRunner'
+TEST_RUNNER = "snapshottest.django.TestRunner"
 
 # Database
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-    }
-}
+DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3",}}
 
 
 # Password validation
@@ -87,26 +83,20 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
-    {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
-    },
+    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",},
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",},
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",},
 ]
 
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = "UTC"
 
 USE_I18N = True
 
@@ -118,4 +108,4 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_URL = "/static/"

--- a/examples/django_project/django_project/tests.py
+++ b/examples/django_project/django_project/tests.py
@@ -5,16 +5,15 @@ from snapshottest.django import SimpleTestCase
 
 def api_client_get(url):
     return {
-        'url': url,
+        "url": url,
     }
 
 
 class TestDemo(SimpleTestCase):
-
     def test_api_me(self):
-        my_api_response = api_client_get('/me')
+        my_api_response = api_client_get("/me")
         self.assertMatchSnapshot(my_api_response)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/examples/django_project/django_project/urls.py
+++ b/examples/django_project/django_project/urls.py
@@ -18,5 +18,5 @@ from lists import views
 
 
 urlpatterns = [
-    url(r'^$', views.home_page, name='home'),
+    url(r"^$", views.home_page, name="home"),
 ]

--- a/examples/django_project/lists/apps.py
+++ b/examples/django_project/lists/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class ListsConfig(AppConfig):
-    name = 'lists'
+    name = "lists"

--- a/examples/django_project/lists/migrations/0001_initial.py
+++ b/examples/django_project/lists/migrations/0001_initial.py
@@ -9,16 +9,23 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-    ]
+    dependencies = []
 
     operations = [
         migrations.CreateModel(
-            name='List',
+            name="List",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=200)),
-                ('description', models.CharField(max_length=200)),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=200)),
+                ("description", models.CharField(max_length=200)),
             ],
         ),
     ]

--- a/examples/django_project/lists/tests.py
+++ b/examples/django_project/lists/tests.py
@@ -3,8 +3,7 @@ from snapshottest.django import TestCase
 
 
 class ListTest(TestCase):
-
     def test_uses_home_template(self):
         List.objects.create(name="test")
-        response = self.client.get('/')
+        response = self.client.get("/")
         self.assertMatchSnapshot(response.content.decode())

--- a/examples/django_project/lists/views.py
+++ b/examples/django_project/lists/views.py
@@ -4,4 +4,4 @@ from lists.models import List
 
 def home_page(request):
     lists = List.objects.all()
-    return render(request, 'home.html', {'lists': lists})
+    return render(request, "home.html", {"lists": lists})

--- a/examples/pytest/test_demo.py
+++ b/examples/pytest/test_demo.py
@@ -6,19 +6,19 @@ from snapshottest.file import FileSnapshot
 
 def api_client_get(url):
     return {
-        'url': url,
+        "url": url,
     }
 
 
 def test_me_endpoint(snapshot):
     """Testing the API for /me"""
-    my_api_response = api_client_get('/me')
+    my_api_response = api_client_get("/me")
     snapshot.assert_match(my_api_response)
 
 
 def test_unicode(snapshot):
     """Simple test with unicode"""
-    expect = u'pépère'
+    expect = u"pépère"
     snapshot.assert_match(expect)
 
 
@@ -27,7 +27,7 @@ class SomeObject(object):
         self.value = value
 
     def __repr__(self):
-        return 'SomeObject({})'.format(repr(self.value))
+        return "SomeObject({})".format(repr(self.value))
 
 
 def test_object(snapshot):
@@ -44,8 +44,8 @@ def test_file(snapshot, tmpdir):
     Test a file snapshot. The file contents will be saved in a sub-folder of the snapshots folder. Useful for large
     files (e.g. media files) that aren't suitable for storage as text inside the snap_***.py file.
     """
-    temp_file = tmpdir.join('example.txt')
-    temp_file.write('Hello, world!')
+    temp_file = tmpdir.join("example.txt")
+    temp_file.write("Hello, world!")
     snapshot.assert_match(FileSnapshot(str(temp_file)))
 
 
@@ -53,12 +53,12 @@ def test_multiple_files(snapshot, tmpdir):
     """
     Each file is stored separately with the snapshot's name inside the module's file snapshots folder.
     """
-    temp_file1 = tmpdir.join('example1.txt')
-    temp_file1.write('Hello, world 1!')
+    temp_file1 = tmpdir.join("example1.txt")
+    temp_file1.write("Hello, world 1!")
     snapshot.assert_match(FileSnapshot(str(temp_file1)))
 
-    temp_file1 = tmpdir.join('example2.txt')
-    temp_file1.write('Hello, world 2!')
+    temp_file1 = tmpdir.join("example2.txt")
+    temp_file1.write("Hello, world 2!")
     snapshot.assert_match(FileSnapshot(str(temp_file1)))
 
 
@@ -70,16 +70,16 @@ class ObjectWithBadRepr(object):
 def test_nested_objects(snapshot):
     obj = ObjectWithBadRepr()
 
-    dict_ = {'key': obj}
-    defaultdict_ = defaultdict(list, [('key', [obj])])
+    dict_ = {"key": obj}
+    defaultdict_ = defaultdict(list, [("key", [obj])])
     list_ = [obj]
     tuple_ = (obj,)
     set_ = set((obj,))
     frozenset_ = frozenset((obj,))
 
-    snapshot.assert_match(dict_, 'dict')
-    snapshot.assert_match(defaultdict_, 'defaultdict')
-    snapshot.assert_match(list_, 'list')
-    snapshot.assert_match(tuple_, 'tuple')
-    snapshot.assert_match(set_, 'set')
-    snapshot.assert_match(frozenset_, 'frozenset')
+    snapshot.assert_match(dict_, "dict")
+    snapshot.assert_match(defaultdict_, "defaultdict")
+    snapshot.assert_match(list_, "list")
+    snapshot.assert_match(tuple_, "tuple")
+    snapshot.assert_match(set_, "set")
+    snapshot.assert_match(frozenset_, "frozenset")

--- a/examples/unittest/test_demo.py
+++ b/examples/unittest/test_demo.py
@@ -4,19 +4,18 @@ import snapshottest
 
 def api_client_get(url):
     return {
-        'url': url,
+        "url": url,
     }
 
 
 class TestDemo(snapshottest.TestCase):
-
     def setUp(self):
         pass
 
     def test_api_me(self):
-        my_api_response = api_client_get('/me')
+        my_api_response = api_client_get("/me")
         self.assertMatchSnapshot(my_api_response)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,22 @@ setup(
     url="https://github.com/syrusakbary/snapshottest",
     # custom PyPI classifier for pytest plugins
     entry_points={
-        "pytest11": ["snapshottest = snapshottest.pytest",],
+        "pytest11": [
+            "snapshottest = snapshottest.pytest",
+        ],
         "nose.plugins.0.10": ["snapshottest = snapshottest.nose:SnapshotTestPlugin"],
     },
     install_requires=["six>=1.10.0", "termcolor", "fastdiff>=0.1.4,<1"],
     tests_require=tests_require,
-    extras_require={"test": tests_require, "pytest": ["pytest",], "nose": ["nose",],},
+    extras_require={
+        "test": tests_require,
+        "pytest": [
+            "pytest",
+        ],
+        "nose": [
+            "nose",
+        ],
+    },
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Pytest",

--- a/setup.py
+++ b/setup.py
@@ -2,54 +2,44 @@
 
 from setuptools import setup, find_packages
 
-with open('README.md') as f:
+with open("README.md") as f:
     readme = f.read()
 
-tests_require = ['six', 'pytest>=4.6', 'pytest-cov', 'nose', 'django>=1.10.6']
+tests_require = ["six", "pytest>=4.6", "pytest-cov", "nose", "django>=1.10.6"]
 
 setup(
-    name='snapshottest',
-    version='0.6.0',
-    description='Snapshot testing for pytest, unittest, Django, and Nose',
+    name="snapshottest",
+    version="0.6.0",
+    description="Snapshot testing for pytest, unittest, Django, and Nose",
     long_description=readme,
     long_description_content_type="text/markdown",
-    author='Syrus Akbary',
-    author_email='me@syrusakbary.com',
-    url='https://github.com/syrusakbary/snapshottest',
+    author="Syrus Akbary",
+    author_email="me@syrusakbary.com",
+    url="https://github.com/syrusakbary/snapshottest",
     # custom PyPI classifier for pytest plugins
     entry_points={
-        'pytest11': [
-            'snapshottest = snapshottest.pytest',
-        ],
-        'nose.plugins.0.10':
-        ['snapshottest = snapshottest.nose:SnapshotTestPlugin']
+        "pytest11": ["snapshottest = snapshottest.pytest",],
+        "nose.plugins.0.10": ["snapshottest = snapshottest.nose:SnapshotTestPlugin"],
     },
-    install_requires=['six>=1.10.0', 'termcolor', 'fastdiff>=0.1.4,<1'],
+    install_requires=["six>=1.10.0", "termcolor", "fastdiff>=0.1.4,<1"],
     tests_require=tests_require,
-    extras_require={
-        'test': tests_require,
-        'pytest': [
-            'pytest',
-        ],
-        'nose': [
-            'nose',
-        ],
-    },
+    extras_require={"test": tests_require, "pytest": ["pytest",], "nose": ["nose",],},
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Framework :: Pytest',
-        'Intended Audience :: Developers',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Topic :: Software Development :: Libraries',
+        "Development Status :: 5 - Production/Stable",
+        "Framework :: Pytest",
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Topic :: Software Development :: Libraries",
     ],
-    license='MIT',
-    packages=find_packages(exclude=('tests', )))
+    license="MIT",
+    packages=find_packages(exclude=("tests",)),
+)

--- a/snapshottest/__init__.py
+++ b/snapshottest/__init__.py
@@ -4,4 +4,4 @@ from .module import assert_match_snapshot
 from .unittest import TestCase
 
 
-__all__ = ['Snapshot', 'GenericRepr', 'assert_match_snapshot', 'TestCase']
+__all__ = ["Snapshot", "GenericRepr", "assert_match_snapshot", "TestCase"]

--- a/snapshottest/diff.py
+++ b/snapshottest/diff.py
@@ -6,18 +6,15 @@ from .formatter import Formatter
 
 
 def format_line(line):
-    line = line.rstrip('\n')
-    if line.startswith('-'):
-        return colored(line, 'green', attrs=['bold'])
-    elif line.startswith('+'):
-        return colored(line, 'red', attrs=['bold'])
-    elif line.startswith('?'):
-        return (
-            colored('') +
-            colored(line, 'yellow', attrs=['bold'])
-        )
+    line = line.rstrip("\n")
+    if line.startswith("-"):
+        return colored(line, "green", attrs=["bold"])
+    elif line.startswith("+"):
+        return colored(line, "red", attrs=["bold"])
+    elif line.startswith("?"):
+        return colored("") + colored(line, "yellow", attrs=["bold"])
 
-    return colored('') + colored(line, 'white', attrs=['dark'])
+    return colored("") + colored(line, "white", attrs=["dark"])
 
 
 class PrettyDiff(object):
@@ -35,10 +32,8 @@ class PrettyDiff(object):
         return repr(self.obj)
 
     def get_diff(self, other):
-        text1 = 'Received \n\n' + self.pretty(self.obj)
-        text2 = 'Snapshot \n\n' + self.pretty(other)
+        text1 = "Received \n\n" + self.pretty(self.obj)
+        text2 = "Snapshot \n\n" + self.pretty(other)
 
         lines = list(compare(text2, text1))
-        return [
-            format_line(line) for line in lines
-        ]
+        return [format_line(line) for line in lines]

--- a/snapshottest/django.py
+++ b/snapshottest/django.py
@@ -20,15 +20,16 @@ class TestRunnerMixin(object):
     def add_arguments(cls, parser):
         super(TestRunnerMixin, cls).add_arguments(parser)
         parser.add_argument(
-            '--snapshot-update', default=False, action='store_true',
-            dest='snapshot_update', help='Update the snapshots automatically.',
+            "--snapshot-update",
+            default=False,
+            action="store_true",
+            dest="snapshot_update",
+            help="Update the snapshots automatically.",
         )
 
     def run_tests(self, test_labels, extra_tests=None, **kwargs):
         result = super(TestRunnerMixin, self).run_tests(
-                test_labels=test_labels,
-                extra_tests=extra_tests,
-                **kwargs
+            test_labels=test_labels, extra_tests=extra_tests, **kwargs
         )
         self.print_report()
         if TestCase.snapshot_should_update:
@@ -39,10 +40,10 @@ class TestRunnerMixin(object):
         return result
 
     def print_report(self):
-        lines = list(reporting_lines('python manage.py test'))
+        lines = list(reporting_lines("python manage.py test"))
         if lines:
             print("\n" + self.separator1)
-            print('SnapshotTest summary')
+            print("SnapshotTest summary")
             print(self.separator2)
             for line in lines:
                 print(line)

--- a/snapshottest/error.py
+++ b/snapshottest/error.py
@@ -9,4 +9,6 @@ class SnapshotNotFound(SnapshotError):
     def __init__(self, module, test_name):
         super(SnapshotNotFound, self).__init__(
             "Snapshot '{snapshot_id!s}' not found in {snapshot_file!s}".format(
-                snapshot_id=test_name, snapshot_file=module.filepath))
+                snapshot_id=test_name, snapshot_file=module.filepath
+            )
+        )

--- a/snapshottest/file.py
+++ b/snapshottest/file.py
@@ -16,7 +16,7 @@ class FileSnapshot(object):
         self.path = path
 
     def __repr__(self):
-        return 'FileSnapshot({})'.format(repr(self.path))
+        return "FileSnapshot({})".format(repr(self.path))
 
     def __eq__(self, other):
         return self.path == other.path
@@ -38,16 +38,20 @@ class FileSnapshotFormatter(BaseFormatter):
         extension = os.path.splitext(value.path)[1]
         snapshot_file = os.path.join(file_snapshot_dir, test.test_name) + extension
         shutil.copy(value.path, snapshot_file)
-        relative_snapshot_filename = os.path.relpath(snapshot_file, test.module.snapshot_dir)
+        relative_snapshot_filename = os.path.relpath(
+            snapshot_file, test.module.snapshot_dir
+        )
         return FileSnapshot(relative_snapshot_filename)
 
     def get_imports(self):
-        return (('snapshottest.file', 'FileSnapshot'),)
+        return (("snapshottest.file", "FileSnapshot"),)
 
     def format(self, value, indent, formatter):
         return repr(value)
 
-    def assert_value_matches_snapshot(self, test, test_value, snapshot_value, formatter):
+    def assert_value_matches_snapshot(
+        self, test, test_value, snapshot_value, formatter
+    ):
         snapshot_path = os.path.join(test.module.snapshot_dir, snapshot_value.path)
         files_identical = filecmp.cmp(test_value.path, snapshot_path, shallow=False)
         assert files_identical, "Stored file differs from test file"

--- a/snapshottest/formatter.py
+++ b/snapshottest/formatter.py
@@ -5,8 +5,8 @@ class Formatter(object):
     formatters = default_formatters()
 
     def __init__(self, imports=None):
-        self.htchar = ' '*4
-        self.lfchar = '\n'
+        self.htchar = " " * 4
+        self.lfchar = "\n"
         self.indent = 0
         self.imports = imports
 

--- a/snapshottest/formatters.py
+++ b/snapshottest/formatters.py
@@ -16,7 +16,9 @@ class BaseFormatter(object):
     def get_imports(self):
         return ()
 
-    def assert_value_matches_snapshot(self, test, test_value, snapshot_value, formatter):
+    def assert_value_matches_snapshot(
+        self, test, test_value, snapshot_value, formatter
+    ):
         test.assert_equals(formatter.normalize(test_value), snapshot_value)
 
     def store(self, test, value):
@@ -55,7 +57,7 @@ class DefaultDictFormatter(TypeFormatter):
 
 
 def trepr(s):
-    text = '\n'.join([repr(line).lstrip('u')[1:-1] for line in s.split('\n')])
+    text = "\n".join([repr(line).lstrip("u")[1:-1] for line in s.split("\n")])
     quotes, dquotes = "'''", '"""'
     if quotes in text:
         if dquotes in text:
@@ -66,17 +68,17 @@ def trepr(s):
 
 
 def format_none(value, indent, formatter):
-    return 'None'
+    return "None"
 
 
 def format_str(value, indent, formatter):
-    if '\n' in value:
+    if "\n" in value:
         # Is a multiline string, so we use '''{}''' for the repr
         return trepr(value)
 
     # Snapshots are saved with `from __future__ import unicode_literals`,
     # so the `u'...'` repr is unnecessary, even on Python 2
-    return repr(value).lstrip('u')
+    return repr(value).lstrip("u")
 
 
 def format_float(value, indent, formatter):
@@ -92,35 +94,43 @@ def format_std_type(value, indent, formatter):
 def format_dict(value, indent, formatter):
     value = SortedDict(value)
     items = [
-        formatter.lfchar + formatter.htchar * (indent + 1) + formatter.format(key, indent) + ': ' +
-        formatter.format(value[key], indent + 1)
+        formatter.lfchar
+        + formatter.htchar * (indent + 1)
+        + formatter.format(key, indent)
+        + ": "
+        + formatter.format(value[key], indent + 1)
         for key in value
     ]
-    return '{%s}' % (','.join(items) + formatter.lfchar + formatter.htchar * indent)
+    return "{%s}" % (",".join(items) + formatter.lfchar + formatter.htchar * indent)
 
 
 def format_list(value, indent, formatter):
-    return '[%s]' % format_sequence(value, indent, formatter)
+    return "[%s]" % format_sequence(value, indent, formatter)
 
 
 def format_sequence(value, indent, formatter):
     items = [
-        formatter.lfchar + formatter.htchar * (indent + 1) + formatter.format(item, indent + 1)
+        formatter.lfchar
+        + formatter.htchar * (indent + 1)
+        + formatter.format(item, indent + 1)
         for item in value
     ]
-    return ','.join(items) + formatter.lfchar + formatter.htchar * indent
+    return ",".join(items) + formatter.lfchar + formatter.htchar * indent
 
 
 def format_tuple(value, indent, formatter):
-    return '(%s%s' % (format_sequence(value, indent, formatter), ',)' if len(value) == 1 else ")")
+    return "(%s%s" % (
+        format_sequence(value, indent, formatter),
+        ",)" if len(value) == 1 else ")",
+    )
 
 
 def format_set(value, indent, formatter):
-    return 'set([%s])' % format_sequence(value, indent, formatter)
+    return "set([%s])" % format_sequence(value, indent, formatter)
 
 
 def format_frozenset(value, indent, formatter):
-    return 'frozenset([%s])' % format_sequence(value, indent, formatter)
+    return "frozenset([%s])" % format_sequence(value, indent, formatter)
 
 
 class GenericFormatter(BaseFormatter):
@@ -139,9 +149,11 @@ class GenericFormatter(BaseFormatter):
         return repr(value)
 
     def get_imports(self):
-        return [('snapshottest', 'GenericRepr')]
+        return [("snapshottest", "GenericRepr")]
 
-    def assert_value_matches_snapshot(self, test, test_value, snapshot_value, formatter):
+    def assert_value_matches_snapshot(
+        self, test, test_value, snapshot_value, formatter
+    ):
         test_value = GenericRepr.from_value(test_value)
         # Assert equality between the representations to provide a nice textual diff.
         test.assert_equals(test_value.representation, snapshot_value.representation)
@@ -159,5 +171,5 @@ def default_formatters():
         TypeFormatter(six.string_types, format_str),
         TypeFormatter((float,), format_float),
         TypeFormatter((int, complex, bool, bytes), format_std_type),
-        GenericFormatter()
+        GenericFormatter(),
     ]

--- a/snapshottest/generic_repr.py
+++ b/snapshottest/generic_repr.py
@@ -3,10 +3,13 @@ class GenericRepr(object):
         self.representation = representation
 
     def __repr__(self):
-        return 'GenericRepr({})'.format(repr(self.representation))
+        return "GenericRepr({})".format(repr(self.representation))
 
     def __eq__(self, other):
-        return isinstance(other, GenericRepr) and self.representation == other.representation
+        return (
+            isinstance(other, GenericRepr)
+            and self.representation == other.representation
+        )
 
     def __hash__(self):
         return hash(self.representation)

--- a/snapshottest/module.py
+++ b/snapshottest/module.py
@@ -25,7 +25,7 @@ class SnapshotModule(object):
         self.visited_snapshots = set()
         self.new_snapshots = set()
         self.failed_snapshots = set()
-        self.imports['snapshottest'].add('Snapshot')
+        self.imports["snapshottest"].add("Snapshot")
 
     def load_snapshots(self):
         try:
@@ -146,21 +146,26 @@ class SnapshotModule(object):
             pass
 
         # Create __init__.py in case doesn't exist
-        open(os.path.join(self.snapshot_dir, '__init__.py'), 'a').close()
+        open(os.path.join(self.snapshot_dir, "__init__.py"), "a").close()
 
         pretty = Formatter(self.imports)
 
-        with codecs.open(self.filepath, 'w', encoding="utf-8") as snapshot_file:
+        with codecs.open(self.filepath, "w", encoding="utf-8") as snapshot_file:
             snapshots_declarations = [
                 """snapshots['{}'] = {}""".format(key, pretty(self.snapshots[key]))
                 for key in sorted(self.snapshots.keys())
             ]
 
-            imports = '\n'.join([
-                'from {} import {}'.format(module, ', '.join(sorted(module_imports)))
-                for module, module_imports in sorted(self.imports.items())
-            ])
-            snapshot_file.write('''# -*- coding: utf-8 -*-
+            imports = "\n".join(
+                [
+                    "from {} import {}".format(
+                        module, ", ".join(sorted(module_imports))
+                    )
+                    for module, module_imports in sorted(self.imports.items())
+                ]
+            )
+            snapshot_file.write(
+                """# -*- coding: utf-8 -*-
 # snapshottest: v1 - https://goo.gl/zC4yUc
 from __future__ import unicode_literals
 
@@ -170,7 +175,10 @@ from __future__ import unicode_literals
 snapshots = Snapshot()
 
 {}
-'''.format(imports, '\n\n'.join(snapshots_declarations)))
+""".format(
+                    imports, "\n\n".join(snapshots_declarations)
+                )
+            )
 
     @classmethod
     def get_module_for_testpath(cls, test_filepath):
@@ -178,11 +186,15 @@ snapshots = Snapshot()
             dirname = os.path.dirname(test_filepath)
             snapshot_dir = os.path.join(dirname, "snapshots")
 
-            snapshot_basename = 'snap_{}.py'.format(os.path.splitext(os.path.basename(test_filepath))[0])
+            snapshot_basename = "snap_{}.py".format(
+                os.path.splitext(os.path.basename(test_filepath))[0]
+            )
             snapshot_filename = os.path.join(snapshot_dir, snapshot_basename)
-            snapshot_module = '{}'.format(os.path.splitext(snapshot_basename)[0])
+            snapshot_module = "{}".format(os.path.splitext(snapshot_basename)[0])
 
-            cls._snapshot_modules[test_filepath] = SnapshotModule(snapshot_module, snapshot_filename)
+            cls._snapshot_modules[test_filepath] = SnapshotModule(
+                snapshot_module, snapshot_filename
+            )
 
         return cls._snapshot_modules[test_filepath]
 
@@ -191,7 +203,7 @@ class SnapshotTest(object):
     _current_tester = None
 
     def __init__(self):
-        self.curr_snapshot = ''
+        self.curr_snapshot = ""
         self.snapshot_counter = 1
 
     @property
@@ -227,12 +239,14 @@ class SnapshotTest(object):
 
     def assert_value_matches_snapshot(self, test_value, snapshot_value):
         formatter = Formatter.get_formatter(test_value)
-        formatter.assert_value_matches_snapshot(self, test_value, snapshot_value, Formatter())
+        formatter.assert_value_matches_snapshot(
+            self, test_value, snapshot_value, Formatter()
+        )
 
     def assert_equals(self, value, snapshot):
         assert value == snapshot
 
-    def assert_match(self, value, name=''):
+    def assert_match(self, value, name=""):
         self.curr_snapshot = name or self.snapshot_counter
         self.visit()
         if self.update:
@@ -256,8 +270,10 @@ class SnapshotTest(object):
         self.module.save()
 
 
-def assert_match_snapshot(value, name=''):
+def assert_match_snapshot(value, name=""):
     if not SnapshotTest._current_tester:
-        raise Exception("You need to use assert_match_snapshot in the SnapshotTest context.")
+        raise Exception(
+            "You need to use assert_match_snapshot in the SnapshotTest context."
+        )
 
     SnapshotTest._current_tester.assert_match(value, name)

--- a/snapshottest/nose.py
+++ b/snapshottest/nose.py
@@ -8,11 +8,11 @@ from .module import SnapshotModule
 from .reporting import reporting_lines
 from .unittest import TestCase
 
-log = logging.getLogger('nose.plugins.snapshottest')
+log = logging.getLogger("nose.plugins.snapshottest")
 
 
 class SnapshotTestPlugin(Plugin):
-    name = 'snapshottest'
+    name = "snapshottest"
     enabled = True
 
     separator1 = "=" * 70
@@ -21,18 +21,18 @@ class SnapshotTestPlugin(Plugin):
     def options(self, parser, env=os.environ):
         super(SnapshotTestPlugin, self).options(parser, env=env)
         parser.add_option(
-            '--snapshot-update',
-            action='store_true',
+            "--snapshot-update",
+            action="store_true",
             default=False,
-            dest='snapshot_update',
-            help='Update the snapshots.'
+            dest="snapshot_update",
+            help="Update the snapshots.",
         )
         parser.add_option(
-            '--snapshot-disable',
-            action='store_true',
-            dest='snapshot_disable',
+            "--snapshot-disable",
+            action="store_true",
+            dest="snapshot_disable",
             default=False,
-            help="Disable special SnapshotTest"
+            help="Disable special SnapshotTest",
         )
 
     def configure(self, options, conf):
@@ -55,8 +55,8 @@ class SnapshotTestPlugin(Plugin):
             return
 
         stream.writeln(self.separator1)
-        stream.writeln('SnapshotTest summary')
+        stream.writeln("SnapshotTest summary")
         stream.writeln(self.separator2)
-        for line in reporting_lines('nosetests'):
+        for line in reporting_lines("nosetests"):
             stream.writeln(line)
         stream.writeln(self.separator1)

--- a/snapshottest/pytest.py
+++ b/snapshottest/pytest.py
@@ -8,24 +8,23 @@ from .reporting import reporting_lines, diff_report
 
 
 def pytest_addoption(parser):
-    group = parser.getgroup('snapshottest')
+    group = parser.getgroup("snapshottest")
     group.addoption(
-        '--snapshot-update',
-        action='store_true',
+        "--snapshot-update",
+        action="store_true",
         default=False,
-        dest='snapshot_update',
-        help='Update the snapshots.'
+        dest="snapshot_update",
+        help="Update the snapshots.",
     )
     group.addoption(
-        '--snapshot-verbose',
-        action='store_true',
+        "--snapshot-verbose",
+        action="store_true",
         default=False,
-        help='Dump diagnostic and progress information.'
+        help="Dump diagnostic and progress information.",
     )
 
 
 class PyTestSnapshotTest(SnapshotTest):
-
     def __init__(self, request=None):
         self.request = request
         super(PyTestSnapshotTest, self).__init__()
@@ -40,12 +39,14 @@ class PyTestSnapshotTest(SnapshotTest):
 
     @property
     def test_name(self):
-        cls_name = getattr(self.request.node.cls, '__name__', '')
-        flattened_node_name = re.sub(r"\s+", " ", self.request.node.name.replace(r"\n", " "))
-        return '{}{} {}'.format(
-            '{}.'.format(cls_name) if cls_name else '',
+        cls_name = getattr(self.request.node.cls, "__name__", "")
+        flattened_node_name = re.sub(
+            r"\s+", " ", self.request.node.name.replace(r"\n", " ")
+        )
+        return "{}{} {}".format(
+            "{}.".format(cls_name) if cls_name else "",
             flattened_node_name,
-            self.curr_snapshot
+            self.curr_snapshot,
         )
 
 
@@ -60,7 +61,7 @@ class SnapshotSession(object):
 
         tr.write_sep("=", "SnapshotTest summary")
 
-        for line in reporting_lines('pytest'):
+        for line in reporting_lines("pytest"):
             tr.write_line(line)
 
 

--- a/snapshottest/reporting.py
+++ b/snapshottest/reporting.py
@@ -6,45 +6,53 @@ from .module import SnapshotModule
 
 def reporting_lines(testing_cli):
     successful_snapshots = SnapshotModule.stats_successful_snapshots()
-    bold = ['bold']
+    bold = ["bold"]
     if successful_snapshots:
-        yield (
-            colored('{} snapshots passed', attrs=bold) + '.'
-        ).format(successful_snapshots)
+        yield (colored("{} snapshots passed", attrs=bold) + ".").format(
+            successful_snapshots
+        )
     new_snapshots = SnapshotModule.stats_new_snapshots()
     if new_snapshots[0]:
         yield (
-            colored('{} snapshots written', 'green', attrs=bold) + ' in {} test suites.'
+            colored("{} snapshots written", "green", attrs=bold) + " in {} test suites."
         ).format(*new_snapshots)
     inspect_str = colored(
-        'Inspect your code or run with `{} --snapshot-update` to update them.'.format(testing_cli),
-        attrs=['dark']
+        "Inspect your code or run with `{} --snapshot-update` to update them.".format(
+            testing_cli
+        ),
+        attrs=["dark"],
     )
     failed_snapshots = SnapshotModule.stats_failed_snapshots()
     if failed_snapshots[0]:
         yield (
-            colored('{} snapshots failed', 'red', attrs=bold) + ' in {} test suites. '
+            colored("{} snapshots failed", "red", attrs=bold)
+            + " in {} test suites. "
             + inspect_str
         ).format(*failed_snapshots)
     unvisited_snapshots = SnapshotModule.stats_unvisited_snapshots()
     if unvisited_snapshots[0]:
         yield (
-            colored('{} snapshots deprecated', 'yellow', attrs=bold) + ' in {} test suites. '
+            colored("{} snapshots deprecated", "yellow", attrs=bold)
+            + " in {} test suites. "
             + inspect_str
         ).format(*unvisited_snapshots)
 
 
 def diff_report(left, right):
     return [
-        'stored snapshot should match the received value',
-        '',
-        colored('> ') +
-        colored('Received value', 'red', attrs=['bold']) +
-        colored(' does not match ', attrs=['bold']) +
-        colored('stored snapshot `{}`'.format(
-            left.snapshottest.test_name,
-        ), 'green', attrs=['bold']) +
-        colored('.', attrs=['bold']),
-        colored('') + '> ' + os.path.relpath(left.snapshottest.module.filepath, os.getcwd()),
-        '',
+        "stored snapshot should match the received value",
+        "",
+        colored("> ")
+        + colored("Received value", "red", attrs=["bold"])
+        + colored(" does not match ", attrs=["bold"])
+        + colored(
+            "stored snapshot `{}`".format(left.snapshottest.test_name,),
+            "green",
+            attrs=["bold"],
+        )
+        + colored(".", attrs=["bold"]),
+        colored("")
+        + "> "
+        + os.path.relpath(left.snapshottest.module.filepath, os.getcwd()),
+        "",
     ] + left.get_diff(right)

--- a/snapshottest/reporting.py
+++ b/snapshottest/reporting.py
@@ -46,7 +46,9 @@ def diff_report(left, right):
         + colored("Received value", "red", attrs=["bold"])
         + colored(" does not match ", attrs=["bold"])
         + colored(
-            "stored snapshot `{}`".format(left.snapshottest.test_name,),
+            "stored snapshot `{}`".format(
+                left.snapshottest.test_name,
+            ),
             "green",
             attrs=["bold"],
         )

--- a/snapshottest/sorted_dict.py
+++ b/snapshottest/sorted_dict.py
@@ -2,7 +2,6 @@ from collections import OrderedDict
 
 
 class SortedDict(OrderedDict):
-
     def __init__(self, values):
         super(SortedDict, self).__init__()
 

--- a/snapshottest/unittest.py
+++ b/snapshottest/unittest.py
@@ -8,7 +8,6 @@ from .reporting import diff_report
 
 
 class UnitTestSnapshotTest(SnapshotTest):
-
     def __init__(self, test_class, test_id, test_filepath, should_update, assertEqual):
         self.test_class = test_class
         self.test_id = test_id
@@ -31,12 +30,8 @@ class UnitTestSnapshotTest(SnapshotTest):
     @property
     def test_name(self):
         class_name = self.test_class.__name__
-        test_name = self.test_id.split('.')[-1]
-        return '{}::{} {}'.format(
-            class_name,
-            test_name,
-            self.curr_snapshot
-        )
+        test_name = self.test_id.split(".")[-1]
+        return "{}::{} {}".format(class_name, test_name, self.curr_snapshot)
 
 
 # Inspired by https://gist.github.com/twolfson/13f5f5784f67fd49b245
@@ -70,8 +65,8 @@ class TestCase(unittest.TestCase):
     def comparePrettyDifs(self, obj1, obj2, msg):
         # self
         # assert obj1 == obj2
-        if not(obj1 == obj2):
-            raise self.failureException('\n'.join(diff_report(obj1, obj2)))
+        if not (obj1 == obj2):
+            raise self.failureException("\n".join(diff_report(obj1, obj2)))
         #     raise self.failureException("DIFF")
 
     @classmethod
@@ -90,7 +85,7 @@ class TestCase(unittest.TestCase):
             test_id=self.id(),
             test_filepath=self._snapshot_file,
             should_update=self.snapshot_should_update,
-            assertEqual=self.assertEqual
+            assertEqual=self.assertEqual,
         )
         self._snapshot_tests.append(self._snapshot)
         SnapshotTest._current_tester = self._snapshot
@@ -101,7 +96,7 @@ class TestCase(unittest.TestCase):
         SnapshotTest._current_tester = None
         self._snapshot = None
 
-    def assert_match_snapshot(self, value, name=''):
+    def assert_match_snapshot(self, value, name=""):
         self._snapshot.assert_match(value, name=name)
 
     assertMatchSnapshot = assert_match_snapshot

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,1 @@
-pytest_plugins = 'pytester'
+pytest_plugins = "pytester"

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -75,7 +75,16 @@ if not six.PY2:
 
 
 @pytest.mark.parametrize(
-    "value", [0, 12.7, True, False, None, float("-inf"), float("inf"),],
+    "value",
+    [
+        0,
+        12.7,
+        True,
+        False,
+        None,
+        float("-inf"),
+        float("inf"),
+    ],
 )
 def test_basic_formatting_parsing(value):
     formatter = Formatter()

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -11,20 +11,23 @@ if not six.PY2:
     import unittest.mock
 
 
-@pytest.mark.parametrize("text_value, expected", [
-    # basics
-    ("abc", "'abc'"),
-    ("", "''"),
-    ("back\\slash", "'back\\\\slash'"),
-    # various embedded quotes (single line)
-    ("""it has "double quotes".""", """'it has "double quotes".'"""),
-    ("""it's got single quotes""", '''"it's got single quotes"'''),
-    ("""it's got "both quotes".""", """'it\\'s got "both quotes".'"""),
-    # multiline gets formatted as triple-quoted
-    ("one\ntwo\n", "'''one\ntwo\n'''"),
-    ("three\n'''quotes", "\"\"\"three\n'''quotes\"\"\""),
-    ("so many\"\"\"\n'''quotes", "'''so many\"\"\"\n\\'\\'\\'quotes'''"),
-])
+@pytest.mark.parametrize(
+    "text_value, expected",
+    [
+        # basics
+        ("abc", "'abc'"),
+        ("", "''"),
+        ("back\\slash", "'back\\\\slash'"),
+        # various embedded quotes (single line)
+        ("""it has "double quotes".""", """'it has "double quotes".'"""),
+        ("""it's got single quotes""", '''"it's got single quotes"'''),
+        ("""it's got "both quotes".""", """'it\\'s got "both quotes".'"""),
+        # multiline gets formatted as triple-quoted
+        ("one\ntwo\n", "'''one\ntwo\n'''"),
+        ("three\n'''quotes", '"""three\n\'\'\'quotes"""'),
+        ("so many\"\"\"\n'''quotes", "'''so many\"\"\"\n\\'\\'\\'quotes'''"),
+    ],
+)
 def test_text_formatting(text_value, expected):
     formatter = Formatter()
     formatted = formatter(text_value)
@@ -42,14 +45,17 @@ def test_text_formatting(text_value, expected):
 # When unicode snapshots are saved in Python 2, there's no easy way to generate
 # a clean unicode_literals repr that doesn't use escape sequences. But the
 # resulting snapshots are still valid on Python 3 (and vice versa).
-@pytest.mark.parametrize("text_value, expected_py3, expected_py2", [
-    ("encodage précis", "'encodage précis'", "'encodage pr\\xe9cis'"),
-    ("精确的编码", "'精确的编码'", "'\\u7cbe\\u786e\\u7684\\u7f16\\u7801'"),
-    # backslash [unicode repr can't just be `"u'{}'".format(value)`]
-    ("omvänt\\snedstreck", "'omvänt\\\\snedstreck'", "'omv\\xe4nt\\\\snedstreck'"),
-    # multiline
-    ("ett\ntvå\n", "'''ett\ntvå\n'''", "'''ett\ntv\\xe5\n'''"),
-])
+@pytest.mark.parametrize(
+    "text_value, expected_py3, expected_py2",
+    [
+        ("encodage précis", "'encodage précis'", "'encodage pr\\xe9cis'"),
+        ("精确的编码", "'精确的编码'", "'\\u7cbe\\u786e\\u7684\\u7f16\\u7801'"),
+        # backslash [unicode repr can't just be `"u'{}'".format(value)`]
+        ("omvänt\\snedstreck", "'omvänt\\\\snedstreck'", "'omv\\xe4nt\\\\snedstreck'"),
+        # multiline
+        ("ett\ntvå\n", "'''ett\ntvå\n'''", "'''ett\ntv\\xe5\n'''"),
+    ],
+)
 def test_non_ascii_text_formatting(text_value, expected_py3, expected_py2):
     expected = expected_py2 if six.PY2 else expected_py3
     formatter = Formatter()
@@ -69,16 +75,7 @@ if not six.PY2:
 
 
 @pytest.mark.parametrize(
-    "value",
-    [
-        0,
-        12.7,
-        True,
-        False,
-        None,
-        float("-inf"),
-        float("inf"),
-    ],
+    "value", [0, 12.7, True, False, None, float("-inf"), float("inf"),],
 )
 def test_basic_formatting_parsing(value):
     formatter = Formatter()

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -21,48 +21,71 @@ def pytest_snapshot_test(request, _apply_options):
 
 class TestPyTestSnapShotTest:
     def test_property_test_name(self, pytest_snapshot_test):
-        pytest_snapshot_test.assert_match('counter')
-        assert pytest_snapshot_test.test_name == \
-            'TestPyTestSnapShotTest.test_property_test_name 1'
+        pytest_snapshot_test.assert_match("counter")
+        assert (
+            pytest_snapshot_test.test_name
+            == "TestPyTestSnapShotTest.test_property_test_name 1"
+        )
 
-        pytest_snapshot_test.assert_match('named', 'named_test')
-        assert pytest_snapshot_test.test_name == \
-            'TestPyTestSnapShotTest.test_property_test_name named_test'
+        pytest_snapshot_test.assert_match("named", "named_test")
+        assert (
+            pytest_snapshot_test.test_name
+            == "TestPyTestSnapShotTest.test_property_test_name named_test"
+        )
 
-        pytest_snapshot_test.assert_match('counter')
-        assert pytest_snapshot_test.test_name == \
-            'TestPyTestSnapShotTest.test_property_test_name 2'
+        pytest_snapshot_test.assert_match("counter")
+        assert (
+            pytest_snapshot_test.test_name
+            == "TestPyTestSnapShotTest.test_property_test_name 2"
+        )
 
 
 def test_pytest_snapshottest_property_test_name(pytest_snapshot_test):
-    pytest_snapshot_test.assert_match('counter')
-    assert pytest_snapshot_test.test_name == \
-        'test_pytest_snapshottest_property_test_name 1'
+    pytest_snapshot_test.assert_match("counter")
+    assert (
+        pytest_snapshot_test.test_name
+        == "test_pytest_snapshottest_property_test_name 1"
+    )
 
-    pytest_snapshot_test.assert_match('named', 'named_test')
-    assert pytest_snapshot_test.test_name == \
-        'test_pytest_snapshottest_property_test_name named_test'
+    pytest_snapshot_test.assert_match("named", "named_test")
+    assert (
+        pytest_snapshot_test.test_name
+        == "test_pytest_snapshottest_property_test_name named_test"
+    )
 
-    pytest_snapshot_test.assert_match('counter')
-    assert pytest_snapshot_test.test_name == \
-        'test_pytest_snapshottest_property_test_name 2'
-
-
-@pytest.mark.parametrize('arg', ['single line string'])
-def test_pytest_snapshottest_property_test_name_parametrize_singleline(pytest_snapshot_test, arg):
-    pytest_snapshot_test.assert_match('counter')
-    assert pytest_snapshot_test.test_name == \
-        'test_pytest_snapshottest_property_test_name_parametrize_singleline[single line string] 1'
+    pytest_snapshot_test.assert_match("counter")
+    assert (
+        pytest_snapshot_test.test_name
+        == "test_pytest_snapshottest_property_test_name 2"
+    )
 
 
-@pytest.mark.parametrize('arg', [
-    '''
+@pytest.mark.parametrize("arg", ["single line string"])
+def test_pytest_snapshottest_property_test_name_parametrize_singleline(
+    pytest_snapshot_test, arg
+):
+    pytest_snapshot_test.assert_match("counter")
+    assert (
+        pytest_snapshot_test.test_name
+        == "test_pytest_snapshottest_property_test_name_parametrize_singleline[single line string] 1"
+    )
+
+
+@pytest.mark.parametrize(
+    "arg",
+    [
+        """
     multi
     line
     string
-    '''
-])
-def test_pytest_snapshottest_property_test_name_parametrize_multiline(pytest_snapshot_test, arg):
-    pytest_snapshot_test.assert_match('counter')
-    assert pytest_snapshot_test.test_name == \
-        'test_pytest_snapshottest_property_test_name_parametrize_multiline[ multi line string ] 1'
+    """
+    ],
+)
+def test_pytest_snapshottest_property_test_name_parametrize_multiline(
+    pytest_snapshot_test, arg
+):
+    pytest_snapshot_test.assert_match("counter")
+    assert (
+        pytest_snapshot_test.test_name
+        == "test_pytest_snapshottest_property_test_name_parametrize_multiline[ multi line string ] 1"
+    )

--- a/tests/test_snapshot_test.py
+++ b/tests/test_snapshot_test.py
@@ -11,9 +11,10 @@ class GenericSnapshotTest(SnapshotTest):
 
     def __init__(self, snapshot_module, update=False, current_test_id=None):
         self._generic_options = {
-            'snapshot_module': snapshot_module,
-            'update': update,
-            'current_test_id': current_test_id or "test_mocked"}
+            "snapshot_module": snapshot_module,
+            "update": update,
+            "current_test_id": current_test_id or "test_mocked",
+        }
         super(GenericSnapshotTest, self).__init__()
 
     @property
@@ -27,8 +28,8 @@ class GenericSnapshotTest(SnapshotTest):
     @property
     def test_name(self):
         return "{} {}".format(
-            self._generic_options["current_test_id"],
-            self.curr_snapshot)
+            self._generic_options["current_test_id"], self.curr_snapshot
+        )
 
     def reinitialize(self):
         """Reset internal state, as though starting a new test run"""
@@ -68,8 +69,7 @@ SNAPSHOTABLE_VALUES = [
     ["a", "b", "c"],  # list
     {"a", "b", "c"},  # set
     ("a", "b", "c"),  # tuple
-    ("a",),           # tuple only have one element
-
+    ("a",),  # tuple only have one element
     # Falsy values:
     None,
     False,
@@ -81,7 +81,6 @@ SNAPSHOTABLE_VALUES = [
     tuple(),
     0,
     0.0,
-
     # dict subclasses:
     # (Make sure snapshots don't just coerce to dict for comparison.)
     OrderedDict([("a", 1), ("b", 2), ("c", 3)]),  # same items as earlier dict
@@ -101,12 +100,19 @@ def test_snapshot_matches_itself(snapshot_test, value):
     assert_snapshot_test_succeeded(snapshot_test)
 
 
-@pytest.mark.parametrize("value, other_value", [
-    pytest.param(value, other_value,
-                 id="snapshot {!r} shouldn't match {!r}".format(value, other_value))
-    for value in SNAPSHOTABLE_VALUES
-    for other_value in SNAPSHOTABLE_VALUES if other_value != value
-])
+@pytest.mark.parametrize(
+    "value, other_value",
+    [
+        pytest.param(
+            value,
+            other_value,
+            id="snapshot {!r} shouldn't match {!r}".format(value, other_value),
+        )
+        for value in SNAPSHOTABLE_VALUES
+        for other_value in SNAPSHOTABLE_VALUES
+        if other_value != value
+    ],
+)
 def test_snapshot_does_not_match_other_values(snapshot_test, value, other_value):
     # first run stores the value as the snapshot
     snapshot_test.assert_match(value)

--- a/tests/test_sorted_dict.py
+++ b/tests/test_sorted_dict.py
@@ -7,35 +7,37 @@ import pytest
 from snapshottest.sorted_dict import SortedDict
 
 
-@pytest.mark.parametrize("key, value", [
-    ('key1', 'value'),
-    ('key2', 42),
-    ('key3', ['value']),
-    ('key4', [['value']]),
-    ('key5', {'key': 'value'}),
-    ('key6', [{'key': 'value'}]),
-    ('key7', {'key': ['value']}),
-    ('key8', [{'key': ['value']}]),
-])
+@pytest.mark.parametrize(
+    "key, value",
+    [
+        ("key1", "value"),
+        ("key2", 42),
+        ("key3", ["value"]),
+        ("key4", [["value"]]),
+        ("key5", {"key": "value"}),
+        ("key6", [{"key": "value"}]),
+        ("key7", {"key": ["value"]}),
+        ("key8", [{"key": ["value"]}]),
+    ],
+)
 def test_sorted_dict(key, value):
     dic = dict([(key, value)])
     assert SortedDict(dic)[key] == value
 
 
 def test_sorted_dict_string_key():
-    value = ('key', 'value')
+    value = ("key", "value")
     dic = dict([value])
     assert SortedDict(dic)[value[0]] == value[1]
 
 
 def test_sorted_dict_int_key():
-    value = (0, 'value')
+    value = (0, "value")
     dic = dict([value])
     assert SortedDict(dic)[value[0]] == value[1]
 
 
 def test_sorted_dict_intenum():
-
     class Fruit(enum.IntEnum):
         APPLE = 1
         ORANGE = 2
@@ -49,7 +51,6 @@ def test_sorted_dict_intenum():
 
 
 def test_sorted_dict_enum():
-
     class Fruit(enum.Enum):
         APPLE = 1
         ORANGE = 2
@@ -63,7 +64,6 @@ def test_sorted_dict_enum():
 
 
 def test_sorted_dict_enum_value():
-
     class Fruit(enum.Enum):
         APPLE = 1
         ORANGE = 2
@@ -74,7 +74,6 @@ def test_sorted_dict_enum_value():
 
 
 def test_sorted_dict_enum_key():
-
     class Fruit(enum.Enum):
         APPLE = 1
         ORANGE = 2


### PR DESCRIPTION
Since most of the open PRs have been merged, it seems like a good time to put in place tooling that would have been too disruptive up to now.

This adds black to the toolchain and enforces code format in CI.