### PR TITLE
Fix developer tooling for black, flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,11 @@ after_success:
 matrix:
   fast_finish: true
   include:
-  - python: '3.8'
-    install: pip install flake8
+  - name: lint
+    python: '3.8'
+    install: make install-tools
     script: make lint
-  include:
-  - python: '3.8'
-    install: pip install black==20.8b1
+  - name: format
+    python: '3.8'
+    install: make install-tools
     script: make format

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
 all: install test
 
+.PHONY: develop
+develop: install install-tools
+
 .PHONY: install
 install:
 	pip install -e ".[test]"
+
+.PHONY: install-tools
+install-tools:
+	pip install flake8 black==20.8b1
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -84,15 +84,29 @@ Set the environment variable `ANSI_COLORS_DISABLED` (to any value), e.g.
 After cloning this repo and configuring a virtualenv for snapshottest (optional, but highly recommended), ensure dependencies are installed by running:
 
 ```sh
-make install
+make develop
 ```
 
-After developing, the full test suite can be evaluated by running:
+After developing, ensure your code is formatted properly by running:
+ 
+```sh
+make format-fix
+```
+
+and then run the full test suite with:
 
 ```sh
 make lint
 # and
 make test
+```
+
+To test locally on all supported Python versions, you can use 
+[tox](https://tox.readthedocs.io/):
+
+```sh
+pip install tox  # (if you haven't before)
+tox
 ```
 
 # Notes

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,10 @@
 
 [flake8]
 exclude = snapshots .tox venv
+# (Although black recommends `max-line-length = 88`, there are still
+# several longer doc strings, which black won't reformat.)
 max-line-length = 120
+extend-ignore = E203
 
 [tool:pytest]
 addopts = --cov snapshottest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+  format
   lint
   py{35,36,37,38}
 
@@ -14,10 +15,16 @@ whitelist_externals =
 passenv =
   CONTINUOUS_INTEGRATION
 
+[testenv:format]
+basepython = python3
+skip_install = True
+commands =
+    make install-tools
+    make format
+
 [testenv:lint]
 basepython = python3
 skip_install = True
-deps =
-    flake8
 commands =
-    flake8
+    make install-tools
+    make lint


### PR DESCRIPTION
Several minor fixes and improvements related to addition
of black code formatter:

Makefile:
* Add `make install-tools` target to install development
  tooling needed for `make format` and `make lint`
* Add `make develop` target that installs tools and
  test package

README:
* Update Contributing section to use `make develop` and
  recommend `make format-fix`
* Note availability of tox for local testing on all Python
  versions

Travis.yml:
* Remove accidental duplicate `include:` that was preventing
  flake8 job from running
* Add names to flake8 and black jobs ("lint" and "format")
  to improve build reports

tox.ini:
* Add "format" tox env that runs black
* Change "lint" tox env to use make targets

setup.cfg:
* Update flake8 config with [recommended options for black][1]
  compatibility (but can't change max-line-length yet
  due to long doc strings)

[1]: https://github.com/psf/black/blob/master/docs/compatible_configs.md#flake8