### PR TITLE
Drop unsupported Python versions from tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
   lint
-  py{27,34,35,36,37,38}
+  py{35,36,37,38}
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
Drop Python 2.7, 3.4