### PR TITLE
Update packaging for Python 3-only distribution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [bdist_wheel]
-universal = 1
 
 [flake8]
 exclude = snapshots .tox venv


### PR DESCRIPTION
Remove universal wheel flag from setup.cfg bdist_wheel config,
because universal wheels must support both Python 2 and 3.[1]

(We can and should still distribute as a non-universal "pure
Python" bdist_wheel because this package does not contain any
compiled platform code.)

[1]: https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels