### PR TITLE
Match black/flake8 max-line-length

### DIFF
--- a/examples/django_project/django_project/settings.py
+++ b/examples/django_project/django_project/settings.py
@@ -87,7 +87,7 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",  # noqa: E501
     },
     {
         "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",

--- a/examples/pytest/test_demo.py
+++ b/examples/pytest/test_demo.py
@@ -32,8 +32,9 @@ class SomeObject(object):
 
 def test_object(snapshot):
     """
-    Test a snapshot with a custom object. The object will be represented in the snapshot using
-    `snapshottest.GenericRepr`. The snapshot will only match if the object's repr remains the same.
+    Test a snapshot with a custom object. The object will be represented in the
+    snapshot using `snapshottest.GenericRepr`. The snapshot will only match if the
+    object's repr remains the same.
     """
     test_value = SomeObject(3)
     snapshot.assert_match(test_value)
@@ -41,8 +42,9 @@ def test_object(snapshot):
 
 def test_file(snapshot, tmpdir):
     """
-    Test a file snapshot. The file contents will be saved in a sub-folder of the snapshots folder. Useful for large
-    files (e.g. media files) that aren't suitable for storage as text inside the snap_***.py file.
+    Test a file snapshot. The file contents will be saved in a sub-folder of the
+    snapshots folder. Useful for large files (e.g. media files) that aren't suitable
+    for storage as text inside the snap_***.py file.
     """
     temp_file = tmpdir.join("example.txt")
     temp_file.write("Hello, world!")
@@ -51,7 +53,8 @@ def test_file(snapshot, tmpdir):
 
 def test_multiple_files(snapshot, tmpdir):
     """
-    Each file is stored separately with the snapshot's name inside the module's file snapshots folder.
+    Each file is stored separately with the snapshot's name inside the module's file
+    snapshots folder.
     """
     temp_file1 = tmpdir.join("example1.txt")
     temp_file1.write("Hello, world 1!")

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,9 +2,7 @@
 
 [flake8]
 exclude = snapshots .tox venv
-# (Although black recommends `max-line-length = 88`, there are still
-# several longer doc strings, which black won't reformat.)
-max-line-length = 120
+max-line-length = 88
 extend-ignore = E203
 
 [tool:pytest]

--- a/snapshottest/file.py
+++ b/snapshottest/file.py
@@ -9,9 +9,9 @@ from .formatters import BaseFormatter
 class FileSnapshot(object):
     def __init__(self, path):
         """
-        Create a file snapshot pointing to the specified `path`. In a snapshot, `path` is considered to be relative to
-        the test module's "snapshots" folder. (This is done to prevent ugly path manipulations inside the snapshot
-        file.)
+        Create a file snapshot pointing to the specified `path`. In a snapshot, `path`
+        is considered to be relative to the test module's "snapshots" folder. (This is
+        done to prevent ugly path manipulations inside the snapshot file.)
         """
         self.path = path
 
@@ -29,7 +29,9 @@ class FileSnapshotFormatter(BaseFormatter):
     def store(self, test, value):
         """
         Copy the file from the test location to the snapshot location.
-        If the original test file has an extension, the snapshot file will use the same extension.
+
+        If the original test file has an extension, the snapshot file will
+        use the same extension.
         """
 
         file_snapshot_dir = self.get_file_snapshot_dir(test)

--- a/snapshottest/pytest.py
+++ b/snapshottest/pytest.py
@@ -84,7 +84,9 @@ def pytest_terminal_summary(terminalreporter):
     terminalreporter.config._snapshotsession.display(terminalreporter)
 
 
-@pytest.mark.trylast  # force the other plugins to initialise, fixes issue with capture not being properly initialised
+# force the other plugins to initialise first
+# (fixes issue with capture not being properly initialised)
+@pytest.mark.trylast
 def pytest_configure(config):
     config._snapshotsession = SnapshotSession(config)
     # config.pluginmanager.register(bs, "snapshottest")

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -67,7 +67,8 @@ def test_pytest_snapshottest_property_test_name_parametrize_singleline(
     pytest_snapshot_test.assert_match("counter")
     assert (
         pytest_snapshot_test.test_name
-        == "test_pytest_snapshottest_property_test_name_parametrize_singleline[single line string] 1"
+        == "test_pytest_snapshottest_property_test_name_parametrize_singleline"
+        "[single line string] 1"
     )
 
 
@@ -87,5 +88,6 @@ def test_pytest_snapshottest_property_test_name_parametrize_multiline(
     pytest_snapshot_test.assert_match("counter")
     assert (
         pytest_snapshot_test.test_name
-        == "test_pytest_snapshottest_property_test_name_parametrize_multiline[ multi line string ] 1"
+        == "test_pytest_snapshottest_property_test_name_parametrize_multiline"
+        "[ multi line string ] 1"
     )


### PR DESCRIPTION
Reformat long doc strings and comments to black's
preferred max-line-length of 88, so that flake8
can use the same setting.

(I'm deliberately noqa-punting on the generated
Django settings.py file.)