### PR TITLE
Allow snapshot to be modified before write

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test:
 	python examples/unittest/test_demo.py
 
 # Run nose
-	nosetests examples/unittest
+	nosetests examples/unittest/test_demo.py
 
 # Run Django Example
 	cd examples/django_project && python manage.py test

--- a/examples/unittest/snapshots/snap_test_using_callback.py
+++ b/examples/unittest/snapshots/snap_test_using_callback.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots["TestUsingCallback::test_call_black 1"] = "some response to the test"

--- a/examples/unittest/test_using_callback.py
+++ b/examples/unittest/test_using_callback.py
@@ -1,0 +1,26 @@
+import unittest
+
+import black
+import snapshottest
+
+
+def black_formatter_callback(data):
+    return black.format_str(data, mode=black.Mode())
+
+
+# Snapshot of this test will be formatted with black
+snapshottest.module.SnapshotModule.register_before_file_write_callback(
+    black_formatter_callback
+)
+
+
+class TestUsingCallback(snapshottest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_call_black(self):
+        self.assertMatchSnapshot("some response to the test")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/snapshottest/module.py
+++ b/snapshottest/module.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 class SnapshotModule(object):
     _snapshot_modules = {}
+    _before_write_callbacks = []
 
     def __init__(self, module, filepath):
         self._original_snapshot = None
@@ -164,8 +165,7 @@ class SnapshotModule(object):
                     for module, module_imports in sorted(self.imports.items())
                 ]
             )
-            snapshot_file.write(
-                """# -*- coding: utf-8 -*-
+            file_data = """# -*- coding: utf-8 -*-
 # snapshottest: v1 - https://goo.gl/zC4yUc
 from __future__ import unicode_literals
 
@@ -176,9 +176,14 @@ snapshots = Snapshot()
 
 {}
 """.format(
-                    imports, "\n\n".join(snapshots_declarations)
-                )
+                imports, "\n\n".join(snapshots_declarations)
             )
+            snapshot_file.write(self._apply_callbacks(file_data))
+
+    def _apply_callbacks(self, data):
+        for callback in self._before_write_callbacks:
+            data = callback(data)
+        return data
 
     @classmethod
     def get_module_for_testpath(cls, test_filepath):
@@ -197,6 +202,14 @@ snapshots = Snapshot()
             )
 
         return cls._snapshot_modules[test_filepath]
+
+    @classmethod
+    def register_before_file_write_callback(cls, callback):
+        cls._before_write_callbacks.append(callback)
+
+    @classmethod
+    def clear_before_file_write_callbacks(cls):
+        cls._before_write_callbacks.clear()
 
 
 class SnapshotTest(object):

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -43,7 +43,7 @@ class TestSnapshotModuleBeforeWriteCallback(object):
 
         module.save()
 
-        with open(filepath) as snap_file:
+        with open(str(filepath)) as snap_file:
             result = snap_file.read()
 
         assert result.startswith("# and another \n# a comment")
@@ -62,7 +62,7 @@ class TestSnapshotModuleBeforeWriteCallback(object):
         SnapshotModule.clear_before_file_write_callbacks()
         module.save()
 
-        with open(filepath) as snap_file:
+        with open(str(filepath)) as snap_file:
             result = snap_file.read()
 
         assert "# a comment" not in result

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -25,3 +25,45 @@ class TestSnapshotModuleLoading(object):
         module = SnapshotModule("tests.snapshots.snap_error", str(filepath))
         with pytest.raises(SyntaxError):
             module.load_snapshots()
+
+
+class TestSnapshotModuleBeforeWriteCallback(object):
+    def test_callback_are_applied_to_data(self, tmpdir):
+        filepath = tmpdir.join("snap_module.py")
+
+        SnapshotModule.register_before_file_write_callback(
+            lambda data: f"# a comment \n{data}"
+        )
+        SnapshotModule.register_before_file_write_callback(
+            lambda data: f"# and another \n{data}"
+        )
+
+        module = SnapshotModule("tests.snapshots.snap_module", str(filepath))
+        module["my_test"] = "result"
+
+        module.save()
+
+        with open(filepath) as snap_file:
+            result = snap_file.read()
+
+        assert result.startswith("# and another \n# a comment")
+        assert "my_test" in result
+
+    def test_can_clear_callback(self, tmpdir):
+        filepath = tmpdir.join("snap_module.py")
+
+        SnapshotModule.register_before_file_write_callback(
+            lambda data: f"# a comment \n{data}"
+        )
+
+        module = SnapshotModule("tests.snapshots.snap_module", str(filepath))
+        module["my_test"] = "result"
+
+        SnapshotModule.clear_before_file_write_callbacks()
+        module.save()
+
+        with open(filepath) as snap_file:
+            result = snap_file.read()
+
+        assert "# a comment" not in result
+        assert "my_test" in result

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -32,10 +32,10 @@ class TestSnapshotModuleBeforeWriteCallback(object):
         filepath = tmpdir.join("snap_module.py")
 
         SnapshotModule.register_before_file_write_callback(
-            lambda data: f"# a comment \n{data}"
+            lambda data: "# a comment \n{}".format(data)
         )
         SnapshotModule.register_before_file_write_callback(
-            lambda data: f"# and another \n{data}"
+            lambda data: "# and another \n{}".format(data)
         )
 
         module = SnapshotModule("tests.snapshots.snap_module", str(filepath))
@@ -53,7 +53,7 @@ class TestSnapshotModuleBeforeWriteCallback(object):
         filepath = tmpdir.join("snap_module.py")
 
         SnapshotModule.register_before_file_write_callback(
-            lambda data: f"# a comment \n{data}"
+            lambda data: "# a comment \n{}".format(data)
         )
 
         module = SnapshotModule("tests.snapshots.snap_module", str(filepath))


### PR DESCRIPTION
This PR introduced simple callbacks which can be used to modify content of the snapshot file before write it.

The main purpose is to allow formatting files (see example with black usage), so it probably can close #89 