### PR TITLE
feat(): add assert_match_with_ignore

### DIFF
--- a/snapshottest/ignore.py
+++ b/snapshottest/ignore.py
@@ -1,0 +1,42 @@
+import re
+
+
+def update_path(current_path, key_or_index, is_dict=False):
+    if is_dict:
+        if current_path == "":
+            return key_or_index
+        return "{}.{}".format(current_path, key_or_index)
+    else:
+        return "{}[{}]".format(current_path, key_or_index)
+
+
+def clear_ignore_keys(data, ignore_keys, current_path=""):
+    if isinstance(data, dict):
+        for key, value in data.items():
+            temp_path = update_path(current_path, key, is_dict=True)
+            matched = match_ignored_key(key, data, ignore_keys, temp_path)
+            if not matched:
+                data[key] = clear_ignore_keys(value, ignore_keys, temp_path)
+        return data
+    elif isinstance(data, list):
+        for index, value in enumerate(data):
+            temp_path = update_path(current_path, index)
+            matched = match_ignored_key(index, data, ignore_keys, temp_path)
+            if not matched:
+                data[index] = clear_ignore_keys(value, ignore_keys, temp_path)
+        return data
+    elif isinstance(data, tuple):
+        return tuple(
+            clear_ignore_keys(value, ignore_keys, update_path(current_path, index))
+            for index, value in enumerate(data)
+        )
+    return data
+
+
+def match_ignored_key(key_or_index, data, ignore_keys, temp_path):
+    for ignored in ignore_keys:
+        escaped = ignored.translate(str.maketrans({"[": r"\[", "]": r"\]"}))
+        if re.match("{}$".format(escaped), temp_path):
+            data[key_or_index] = None
+            return True
+    return False

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -1,0 +1,27 @@
+from time import time
+from snapshottest.ignore import clear_ignore_keys
+
+DATA = {
+    "name": {
+        "id": time(),
+        "first": "Manual",
+        "last": "gonazales",
+        "cities": ["1", "2", {"id": time()}],
+    }
+}
+
+DATA_EXPECTED = {
+    "name": {
+        "id": None,
+        "first": "Manual",
+        "last": "gonazales",
+        "cities": [None, "2", {"id": None}],
+    }
+}
+
+
+def test_clear_works():
+    clean_data = clear_ignore_keys(
+        DATA, ignore_keys=["name.id", "name.cities[0]", "name.cities[2].id"]
+    )
+    assert clean_data == DATA_EXPECTED


### PR DESCRIPTION
# Description
This is a complementary method to allow asserting snapshots while ignoring certain fields.
- Based on https://github.com/syrusakbary/snapshottest/pull/102 and solving #21 #68  #32
- Our team at https://github.com/reversso has been using this as a monkey patch of the library and we wanted to share (and hopefully contribute to this awesome library )
- I would like to give credit to @HeyHugo since we based our solution on his PR #102 
# Why? 
- The most classic use case for this method is autogenerated `IDs` that will change in between test batteries. (For example if databases are reused or random test order implies `IDs` are not unique)
- Also when using random generated data without seeds

# Solution
It covers recursive:
- Lists
- Dictionaries
- Tuples

Additionally, it allows to exclude multiple values in the same "level". 
```python
 def assert_match_with_ignore(self, data, ignore_keys):
        """Extension of assert_match to ignore data.
        Args:
            data (dict,list,tuple): Data to be asserted
            ignored_keys (list): List of strings containing path to be ignored,
            special character "[.]" can be used to ignore multiple elements in list.
            (See Example 2)
        Returns:
            None: Asserts if the values are the same
        Raises:
            AssertionError: If the snapshot is different than the incoming data
        Examples:
            Test examples at: apps/tests/utils/test_asserts.py
            Example 1:
            >>> data={"dict1": {"dict2": {"dict3": {"id": "importantId", "other": "value"}}}}
            >>> ignore_keys=["dict1.dict2.dict3.id"]
            >>> assert_match_with_ignore(data,ignore_keys)
                # Will create the following snapshot
                snapshots['example_snapshot'] = {
                    'dict1': {
                        'dict2': {
                            'dict3': {
                                'id': None,
                                'other': 'value'
                            }
                        }
                    }
                }
            ---
            Example 2:
            >>> data=[
                    {
                    "name": "objectList",
                    "children": [
                        {"id": "random_string", "name": "child_1",},
                        {"id": "random_string2", "name": "child_2",},
                    ],
                    }
                ]
            >>> ignore_keys=["[0].children[.].id"]
            >>> assert_match_with_ignore(data,ignore_keys)
                # Will create the following snapshot
                snapshots['example2_snapshot'] = [
                    {
                    "name": "objectList",
                    "children": [
                        {"id": None, "name": "child_1",},
                        {"id": None, "name": "child_2",},
                    ],
                    }
                ]
        """

        self.assert_match(clear_ignore_keys(data, ignore_keys))
```