### PR TITLE
Remove unittest's TestCase from top level package import.

### DIFF
--- a/snapshottest/__init__.py
+++ b/snapshottest/__init__.py
@@ -1,7 +1,6 @@
 from .snapshot import Snapshot
 from .generic_repr import GenericRepr
 from .module import assert_match_snapshot
-from .unittest import TestCase
 
 
-__all__ = ["Snapshot", "GenericRepr", "assert_match_snapshot", "TestCase"]
+__all__ = ["Snapshot", "GenericRepr", "assert_match_snapshot"]


### PR DESCRIPTION
Rationale
=========
When importing from `snapshottest` package this might result in confusion as the `TestCase` class name is used by multiple subpackages.


```py
from snapshottest import TestCase  # This results in error for example in a django application.
```

Solution
======
Prevent wrong imports by letting the caller specify the `unittest` package explicitly in the import.

