### PR TITLE
Add typed enums support for TypeFormatter

### DIFF
--- a/snapshottest/formatters.py
+++ b/snapshottest/formatters.py
@@ -37,8 +37,6 @@ class TypeFormatter(BaseFormatter):
         return isinstance(value, self.types)
 
     def format(self, value, indent, formatter):
-        if isinstance(value, Enum):
-            value = value.value
         return self.format_func(value, indent, formatter)
 
 
@@ -135,6 +133,10 @@ def format_frozenset(value, indent, formatter):
     return "frozenset([%s])" % format_sequence(value, indent, formatter)
 
 
+def format_enum(value, indent, formatter):
+    return formatter(value.value)
+
+
 class GenericFormatter(BaseFormatter):
     def can_format(self, value):
         return True
@@ -164,6 +166,7 @@ class GenericFormatter(BaseFormatter):
 def default_formatters():
     return [
         TypeFormatter(type(None), format_none),
+        TypeFormatter((Enum,), format_enum),
         DefaultDictFormatter(defaultdict, format_dict),
         CollectionFormatter(dict, format_dict),
         CollectionFormatter(tuple, format_tuple),

--- a/snapshottest/formatters.py
+++ b/snapshottest/formatters.py
@@ -1,5 +1,6 @@
 import math
 from collections import defaultdict
+from enum import Enum
 
 from .sorted_dict import SortedDict
 from .generic_repr import GenericRepr
@@ -36,6 +37,8 @@ class TypeFormatter(BaseFormatter):
         return isinstance(value, self.types)
 
     def format(self, value, indent, formatter):
+        if isinstance(value, Enum):
+            value = value.value
         return self.format_func(value, indent, formatter)
 
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from enum import Enum
+
 import pytest
 from math import isnan
 
@@ -85,3 +87,19 @@ def test_formatting_parsing_nan():
     formatted = formatter(value)
     parsed = eval(formatted)
     assert isnan(parsed)
+
+
+class IntEnum(int, Enum):
+    ONE = 1
+    TWO = 2
+
+
+class StrEnum(str, Enum):
+    A = "aaa"
+    B = "bbb"
+
+
+@pytest.mark.parametrize("value", list(IntEnum) + list(StrEnum))
+def test_typed_enums(value):
+    formatter = Formatter()
+    assert formatter(value) == formatter(value.value)


### PR DESCRIPTION
This patch allows producing more correct output for typed enum values.
See also #120 