### PR TITLE
fixed an issue with counter values at assert_match()

### DIFF
--- a/snapshottest/module.py
+++ b/snapshottest/module.py
@@ -266,6 +266,10 @@ class SnapshotTest(object):
                 try:
                     self.assert_value_matches_snapshot(value, prev_snapshot)
                 except AssertionError:
+                    # counter must be increased before the exception is raised
+                    # otherwise every next test case will be compared with the
+                    # last snapshot that raised the error
+                    self.snapshot_counter += 1
                     self.fail()
                     raise
 


### PR DESCRIPTION
test_cases = [1, 2, 3, 4, 5, 6, 7, 8, 9]
snapshots =  [1, 2, 3, 7, 5, 6, 7, 8, 9]

Now when 4 is compared to 7 an AssertionError is raised but the value of the counter is not updated. Thus, every next test case will be compared to 7 and every test will fail, until a test_case with value 7 is reached.  Then the counter will be updated, but  every new case will now be compared to 5. This is a critical error when someone is trying to test lists of items.