### PR TITLE
fix: adding super().setUp() call to unittest.TestCase

### DIFF
--- a/snapshottest/unittest.py
+++ b/snapshottest/unittest.py
@@ -77,6 +77,7 @@ class TestCase(unittest.TestCase):
 
     def setUp(self):
         """Do some custom setup"""
+        super().setUp()
         # print dir(self.__module__)
         self.addTypeEqualityFunc(PrettyDiff, self.comparePrettyDifs)
         self._snapshot = UnitTestSnapshotTest(


### PR DESCRIPTION
This is required in cases where mixins are used for composing `TestCase`s.