### PR TITLE
Use importlib (Python 3.12 compatible)

### DIFF
--- a/snapshottest/module.py
+++ b/snapshottest/module.py
@@ -1,8 +1,8 @@
 import codecs
 import errno
 import os
-import imp
 from collections import defaultdict
+from importlib.machinery import SourceFileLoader
 import logging
 
 from .snapshot import Snapshot
@@ -33,7 +33,7 @@ class SnapshotModule(object):
 
     def load_snapshots(self):
         try:
-            source = imp.load_source(self.module, self.filepath)
+            source = SourceFileLoader(self.module, self.filepath).load_module()
         # except FileNotFoundError:  # Python 3
         except (IOError, OSError) as err:
             if err.errno == errno.ENOENT:


### PR DESCRIPTION
Replace `imp` usage with `importlib`
`imp` has been removed in Python 3.12 so this should make this package compatible.

- https://github.com/syrusakbary/snapshottest/issues/142#issuecomment-703166275

Tests all pass locally on Python 3.12.

- This implementation is much simpler than #168 